### PR TITLE
Requirements.txt: Tighten version check on pyabf

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,5 +8,5 @@ pillow
 argschema
 allensdk
 dictdiffer
-pyabf>=2.0.18
+pyabf==2.0.18
 pynwb # unreleased development version actually


### PR DESCRIPTION
Since version 2.0.19 pyabf is being rewritten. In order to keep our
ABF -> NWB conversion working we stick to the old API.

Porting to the new API is planned once it is finalized.