### PR TITLE
requirements.txt: Use minimum version for pynwb

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,4 +9,4 @@ argschema
 allensdk
 dictdiffer
 pyabf==2.0.18
-pynwb # unreleased development version actually
+pynwb>=0.5.1


### PR DESCRIPTION
Since 9/15/2018 we have a new pynwb release which works for us.