### PR TITLE
Add regression tests for X-NWB converters

### DIFF
--- a/ipfx/bin/run_x_to_nwb_conversion.py
+++ b/ipfx/bin/run_x_to_nwb_conversion.py
@@ -15,7 +15,13 @@ def convert(inFileOrFolder, overwrite=False, fileType=None):
 
     Supported fileformats:
         - ABF v2 files created by Clampex
-        - DAT files create by Patchmaster v2x90
+        - DAT files created by Patchmaster v2x90
+
+    :param inFileOrFolder: path to a file or folder
+    :param overwrite: overwrite output file, defaults to `False`
+    :param fileType: file type to be converted, must be passed iff `inFileOrFolder` refers to a folder
+
+    :return: path of the created NWB file
     """
 
     if not os.path.exists(inFileOrFolder):
@@ -46,6 +52,8 @@ def convert(inFileOrFolder, overwrite=False, fileType=None):
         DatConverter(inFileOrFolder, outFile)
     else:
         raise ValueError(f"The extension {ext} is currently not supported.")
+
+    return outFile
 
 
 def main():

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,1 +1,2 @@
-pytest>=2.9.2
+pytest>=3.3.0
+pytest-xdist

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,3 +24,9 @@ def spike_test_var_dt():
 @pytest.fixture()
 def spike_test_high_init_dvdt():
     return load_array_from_zip_file("data/spike_test_high_init_dvdt.txt.zip", "spike_test_high_init_dvdt.txt")
+
+def pytest_addoption(parser):
+    parser.addoption("--do-x-nwb-tests",
+                     action="store_true",
+                     default=False,
+                     help="run file regression tests for conversion to NWBv2")

--- a/tests/test_x_nwb.py
+++ b/tests/test_x_nwb.py
@@ -1,0 +1,97 @@
+"""
+Regression tests for the DAT/ABF conversion to NWB.
+
+Idea:
+    A list of raw data files is converted to NWB and the new NWB file
+    is compared to the NWB from earlier runs.
+
+
+Running the tests:
+    By default these tests are expensive and thus skipped by default.
+    To run them pass `--do-x-nwb-tests` on the command line. Tests execution
+    can be parallelized via passing `--numprocesses auto`.
+"""
+
+import pytest
+import glob
+import os
+import subprocess
+
+import pyabf
+
+from ipfx.x_to_nwb.ABFConverter import ABFConverter
+from ipfx.bin.run_x_to_nwb_conversion import convert
+from test_x_nwb_helper import fetch_and_extract_zip
+
+
+if not pytest.config.getoption("--do-x-nwb-tests"):
+    pytest.skip("--do-x-nwb-tests is missing, skipping tests",
+                allow_module_level=True)
+
+
+def get_raw_files():
+
+    # we have to do that here as we need to have the files
+    # before we can decide how many tests we have
+    fetch_and_extract_zip("reference_dat.zip")
+    fetch_and_extract_zip("reference_dat_nwb.zip")
+
+    fetch_and_extract_zip("reference_abf.zip")
+    fetch_and_extract_zip("reference_abf_nwb.zip")
+
+    fetch_and_extract_zip("reference_atf.zip")
+    ABFConverter.atfStorage = pyabf.ATFStorage("reference_atf")
+
+    files = []
+
+    for ext in ["abf", "dat"]:
+        folder = f"reference_{ext}"
+        files += glob.glob(os.path.join(folder, f"*.{ext}"))
+
+    return files
+
+
+@pytest.fixture(scope="module")
+def h5diff_present():
+    assert subprocess.run(["h5diff", "--version"]).returncode == 0
+
+
+@pytest.fixture(scope="module", params=get_raw_files())
+def raw_file(request, h5diff_present):
+    return request.param
+
+
+def test_file_level_regressions(raw_file):
+
+    base, ext = os.path.splitext(raw_file)
+
+    ref_folder = f"reference_{ext[1:]}_nwb"
+
+    new_file = convert(raw_file, overwrite=True)
+    ref_file = os.path.join(ref_folder, os.path.basename(new_file))
+
+    assert os.path.isfile(ref_file)
+    assert os.path.isfile(new_file)
+
+    prog_args = ["-c",  "--follow-symlinks", "--no-dangling-links"]
+
+    # list of objects to ignore
+    # these objects always change
+    ignore_paths = ["--exclude-path", "/general/source_script",
+                    "--exclude-path", "/file_create_date",
+                    "--exclude-path", "/identifier"]
+
+    nwb_files = [ref_file, new_file]
+
+    # MSYS_NO_PATHCONV is for users how are running the tests in a MSYS
+    # bash on windows.
+    # See https://stackoverflow.com/a/34386471/4859183 for some background.
+    out = subprocess.run(["h5diff"] + prog_args + ignore_paths + nwb_files,
+                         env={"MSYS_NO_PATHCONV": "1"}, encoding="ascii",
+                         stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+
+    # h5diff exit codes:
+    # 0 if no differences, 1 if differences found, 2 if error
+
+    assert len(out.stdout) == 0
+    assert out.returncode == 0

--- a/tests/test_x_nwb_helper.py
+++ b/tests/test_x_nwb_helper.py
@@ -1,0 +1,172 @@
+"""
+Regenerating NWB files:
+
+    cd tests
+    rm *zip *sha256
+    python test_x_nwb_recreate_files.py
+    # upload the zip/sha256 files
+
+Notes:
+    The reference DAT package file has only data acquired with
+    Patchmaster 2x90.
+
+    The list of files was generated with:
+    grep "\bVersion" *pymeta | grep 2x90 | uniq | cut -f 1 -d ":" \
+    | sed -s "s/.pymeta//g" | xargs zip -u reference_dat_files.zip
+
+    pymeta files are created by `hr_bundle.py`.
+"""
+
+
+import urllib.request
+import shutil
+import hashlib
+import os
+import glob
+from zipfile import ZipFile, ZIP_DEFLATED
+
+import pyabf
+
+from ipfx.x_to_nwb.ABFConverter import ABFConverter
+from ipfx.bin.run_x_to_nwb_conversion import convert
+
+BASE_URL = "https://www.byte-physics.de/Downloads/allensdk-test-data/"
+
+def fetch_and_extract_zip(filename, base_url = BASE_URL):
+    """
+    Download regression test data.
+
+    Files which must reside in `base_url`:
+    base_url + filename: ZIP file, will be extracted into `filename`
+                         without extension on success
+    base_url + filename + ".sha256": Holds the SHA256 hash of the ZIP file
+
+    The usage of the hash file allows us to skip downloading the ZIP file if it
+    is already present and in the current version.
+    """
+
+    def download_file(url, output_filepath):
+        """
+        Download the file pointed to by `url` and store it in
+        `output_filepath`.
+        """
+
+        with urllib.request.urlopen(url) as response:
+            with open(output_filepath, "wb") as out_file:
+                shutil.copyfileobj(response, out_file)
+
+    def compare_checksums(path, checksum):
+        """
+        Return `True` if `path` has the SHA256 checksum given in `checksum`.
+
+        checksum_file is expected to have a format compatible to the
+        `sha256sum` commandline tool.
+
+        Format:
+        ```
+            3bd33[...] *reference_dat_files.zip
+        ```
+        """
+
+        with open(path, "rb") as f:
+            existing = hashlib.sha256(f.read()).hexdigest()
+
+        with open(checksum, "rb") as f:
+            expected = f.read().decode("ascii").strip().split(" ")[0]
+
+        return existing == expected
+
+    checksum = filename + ".sha256"
+    download_file(base_url + checksum, checksum)
+
+    folder = os.path.splitext(filename)[0]
+    needs_extract = not os.path.isdir(folder)
+
+    if (os.path.isfile(filename)
+        and not compare_checksums(filename, checksum)) \
+       or not os.path.isfile(filename):  # file not present
+        print(f"Download large file {filename}, please be patient.")
+        download_file(base_url + filename, filename)
+        needs_extract = True
+
+        if not compare_checksums(filename, checksum):
+            raise ValueError("File and its checksum don't match!")
+
+    if needs_extract:
+        with ZipFile(filename, "r") as f:
+            print(f"Extracting {filename} into {folder}, please be patient.")
+            f.testzip()
+            f.extractall(folder)
+
+
+
+def create_files_for_upload(ext):
+    """
+    Create the zip files and their checksum files for the given format.
+    These files can be uploaded directly to `BASE_URL`.
+    """
+
+    fetch_and_extract_zip(f"reference_{ext}.zip")
+
+    if ext == "abf":
+        fetch_and_extract_zip("reference_atf.zip")
+        ABFConverter.atfStorage = pyabf.ATFStorage("reference_atf")
+
+    folder = f"reference_{ext}"
+    basename = f"reference_{ext}"
+    zip_files(folder, basename, f".{ext}")
+
+    if ext == "atf":
+        return None
+
+    files = glob.glob(os.path.join(folder, "*." + ext))
+
+    for f in files:
+        convert(f, overwrite=True)
+
+    zip_files(folder, basename + "_nwb", ".nwb")
+
+
+def zip_files(folder, filename, extension):
+    """
+    Zip all files matching `extension` in `folder` and save them into
+    `filename + ".zip"` and create a checksum file as well.
+    """
+
+    if not os.path.isdir(folder):
+        raise ValueError(f"{folder} needs to be an existing folder.")
+
+    cwd = os.getcwd()
+
+    try:
+        os.chdir(folder)
+        files = glob.glob("*" + extension)
+
+        if len(files) == 0:
+            raise ValueError(f"Could not find any files in {folder}")
+
+        filename = os.path.join("..", filename) + ".zip"
+        checksum = filename + ".sha256"
+
+        with ZipFile(filename, "w", compression=ZIP_DEFLATED) as z:
+            for f in files:
+                z.write(f)
+
+        with open(filename, "rb") as f:
+            h = hashlib.sha256(f.read()).hexdigest()
+            with open(checksum, "wb") as f:
+                content = f"{h} *{os.path.basename(filename)}\n"
+                f.write(content.encode("ascii"))
+    finally:
+        os.chdir(cwd)
+
+
+def main():
+    create_files_for_upload("dat")
+    # create_files_for_upload("atf")
+    create_files_for_upload("abf")
+    pass
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Run the tests with

```
py.test.exe --numprocesses auto --do-x-nwb-tests test_x_nwb.py
```

Takes here around 3 minutes.
The files are downloaded on-demand only as I've added some caching scheme.

Closes #83, #84.