### PR TITLE
X-NWB: Upgrade to latest pynwb version

### DIFF
--- a/ipfx/x_to_nwb/ABFConverter.py
+++ b/ipfx/x_to_nwb/ABFConverter.py
@@ -195,7 +195,7 @@ class ABFConverter:
         source = PLACEHOLDER
         session_description = getFileComments(self.abfs)
         identifier = sha256(" ".join([abf.fileGUID for abf in self.abfs]).encode()).hexdigest()
-        session_start_time = self.refabf.abfDateTime
+        session_start_time = datetime.strptime(self.refabf.abfDateTime, ABF_TIMESTAMP_FORMAT)
         creatorName = self.refabf._stringsIndexed.uCreatorName
         creatorVersion = formatVersion(self.refabf.creatorVersion)
         experiment_description = (f"{creatorName} v{creatorVersion}")
@@ -205,7 +205,6 @@ class ABFConverter:
 
         return NWBFile(source=source,
                        session_description=session_description,
-                       file_create_date=datetime.utcnow().isoformat(),
                        identifier=identifier,
                        session_start_time=session_start_time,
                        experimenter=None,

--- a/ipfx/x_to_nwb/DatConverter.py
+++ b/ipfx/x_to_nwb/DatConverter.py
@@ -203,7 +203,6 @@ class DatConverter:
 
         return NWBFile(source=source,
                        session_description=session_description,
-                       file_create_date=datetime.utcnow().isoformat(),
                        identifier=identifier,
                        session_start_time=self.session_start_time,
                        experimenter=None,


### PR DESCRIPTION
This pynwb version finally accepts only datetime objects for
session_start_time and file_create_date.

Requires a unreleased pynwb version from master.

See also https://github.com/NeurodataWithoutBorders/pynwb/commit/8d6bd2eed3a402ae3d71ef3ce985634a0d592e74.