### PR TITLE
X-NWB/DATConverter/ABFConverter: Add sweep numbers

### DIFF
--- a/ipfx/bin/nwb_to_pdf.py
+++ b/ipfx/bin/nwb_to_pdf.py
@@ -310,7 +310,7 @@ def check_stimset_reconstruction(nwbfile, outfile):
                         acq = nwb.acquisition[acq_key]
 
                     description = json.loads(acq.description)
-                    cycle_id = description['cycle_id']
+                    cycle_id = str(description['cycle_id'])
 
                     abs_diff = abs(acq.data[()] - stim.data[()])
                     rel_diff = abs(acq.data[()] - stim.data[()]) / acq.data[()]

--- a/ipfx/x_to_nwb/ABFConverter.py
+++ b/ipfx/x_to_nwb/ABFConverter.py
@@ -14,7 +14,7 @@ from pynwb.icephys import IntracellularElectrode
 
 from ipfx.x_to_nwb.utils import PLACEHOLDER, V_CLAMP_MODE, I_CLAMP_MODE, \
      parseUnit, getStimulusSeriesClass, getAcquiredSeriesClass, createSeriesName, createCompressedDataset, \
-     getPackageInfo
+     getPackageInfo, createCycleID
 
 ABF_TIMESTAMP_FORMAT = "%Y-%m-%dT%H:%M:%S.%f"
 
@@ -256,7 +256,7 @@ class ABFConverter:
 
         for file_index, abf in enumerate(self.abfs):
             for sweep in range(abf.sweepCount):
-                cycle_id = f"{file_index}.{sweep}"
+                cycle_id = createCycleID([file_index, sweep], total=self.totalSeriesCount)
                 for channel in range(abf.channelCount):
 
                     if not abf._dacSection.nWaveformEnable[channel]:
@@ -282,6 +282,7 @@ class ABFConverter:
 
                     stimulus = seriesClass(name=name,
                                            data=data,
+                                           sweep_number=cycle_id,
                                            unit=unit,
                                            electrode=electrode,
                                            gain=gain,
@@ -305,7 +306,7 @@ class ABFConverter:
 
         for file_index, abf in enumerate(self.abfs):
             for sweep in range(abf.sweepCount):
-                cycle_id = f"{file_index}.{sweep}"
+                cycle_id = createCycleID([file_index, sweep], total=self.totalSeriesCount)
                 for channel in range(abf.channelCount):
                     abf.setSweep(sweep, channel=channel, absoluteTime=True)
                     name, counter = createSeriesName("index", counter, total=self.totalSeriesCount)
@@ -338,6 +339,7 @@ class ABFConverter:
 
                         acquistion_data = seriesClass(name=name,
                                                       data=data,
+                                                      sweep_number=cycle_id,
                                                       unit=unit,
                                                       electrode=electrode,
                                                       gain=gain,
@@ -361,6 +363,7 @@ class ABFConverter:
                         capacitance_compensation = np.nan
                         acquistion_data = seriesClass(name=name,
                                                       data=data,
+                                                      sweep_number=cycle_id,
                                                       unit=unit,
                                                       electrode=electrode,
                                                       gain=gain,

--- a/ipfx/x_to_nwb/DatConverter.py
+++ b/ipfx/x_to_nwb/DatConverter.py
@@ -14,7 +14,7 @@ from ipfx.x_to_nwb.hr_nodes import TraceRecord, ChannelRecordStimulus
 from ipfx.x_to_nwb.hr_stimsetgenerator import StimSetGenerator
 from ipfx.x_to_nwb.utils import PLACEHOLDER, V_CLAMP_MODE, I_CLAMP_MODE, \
      parseUnit, getStimulusSeriesClass, getAcquiredSeriesClass, createSeriesName, createCompressedDataset, \
-     getPackageInfo, getChannelRecordIndex, getStimulusRecordIndex
+     getPackageInfo, getChannelRecordIndex, getStimulusRecordIndex, createCycleID
 
 
 class DatConverter:
@@ -249,7 +249,7 @@ class DatConverter:
         for group in self.bundle.pul:
             for series in group:
                 for sweep in series:
-                    cycle_id = f"{group.GroupCount}.{series.SeriesCount}.{sweep.SweepCount}"
+                    cycle_id = createCycleID([group.GroupCount, series.SeriesCount, sweep.SweepCount], total=self.totalSeriesCount)
                     stimRec = self.bundle.pgf[getStimulusRecordIndex(sweep)]
                     for trace in sweep:
                         stimset = generator.fetch(sweep, trace)
@@ -285,6 +285,7 @@ class DatConverter:
 
                         timeSeries = seriesClass(name=name,
                                                  data=data,
+                                                 sweep_number=cycle_id,
                                                  unit=unit,
                                                  electrode=electrode,
                                                  gain=gain,
@@ -327,7 +328,7 @@ class DatConverter:
         for group in self.bundle.pul:
             for series in group:
                 for sweep in series:
-                    cycle_id = f"{group.GroupCount}.{series.SeriesCount}.{sweep.SweepCount}"
+                    cycle_id = createCycleID([group.GroupCount, series.SeriesCount, sweep.SweepCount], total=self.totalSeriesCount)
                     for trace_index, trace in enumerate(sweep):
                         name, counter = createSeriesName("index", counter, total=self.totalSeriesCount)
                         data = createCompressedDataset(self.bundle.data[trace])
@@ -377,6 +378,7 @@ class DatConverter:
 
                             acquistion_data = seriesClass(name=name,
                                                           data=data,
+                                                          sweep_number=cycle_id,
                                                           unit=unit,
                                                           electrode=electrode,
                                                           gain=gain,
@@ -409,6 +411,7 @@ class DatConverter:
 
                             acquistion_data = seriesClass(name=name,
                                                           data=data,
+                                                          sweep_number=cycle_id,
                                                           unit=unit,
                                                           electrode=electrode,
                                                           gain=gain,

--- a/ipfx/x_to_nwb/utils.py
+++ b/ipfx/x_to_nwb/utils.py
@@ -65,6 +65,32 @@ def createSeriesName(prefix, number, total):
     return f"{prefix}_{number:0{math.ceil(math.log(total, 10))}d}", number + 1
 
 
+def createCycleID(numbers, total):
+    """
+    Create an integer from all numbers which is unique for that combination.
+
+    :param: numbers:
+        Iterable holding non-negative integer numbers
+
+    :param: total:
+        Total number of TimeSeries written to the NWB file
+    """
+
+    assert total > 0, f"Unexpected value for total {total}"
+
+    places = max(math.ceil(math.log(total, 10)), 1)
+
+    result = 0
+
+    for idx, n in enumerate(reversed(numbers)):
+        assert n >= 0, f"Unexpected value {n} at index {idx}"
+        assert n < 10**places, f"Unexpected value {n} which is larger than {total}"
+
+        result += n * (10**(idx * places))
+
+    return result
+
+
 def createCompressedDataset(array):
     """
     Request compression for the given array and return it wrapped.

--- a/tests/test_x_nwb.py
+++ b/tests/test_x_nwb.py
@@ -20,6 +20,7 @@ import subprocess
 import pyabf
 
 from ipfx.x_to_nwb.ABFConverter import ABFConverter
+from ipfx.x_to_nwb.utils import createCycleID
 from ipfx.bin.run_x_to_nwb_conversion import convert
 from .test_x_nwb_helper import fetch_and_extract_zip
 
@@ -97,3 +98,13 @@ def test_file_level_regressions(raw_file):
         print(out.stdout)
 
     assert out.returncode == 0
+
+
+def test_createCycleID():
+
+    assert createCycleID([1, 2, 3, 4], total=2)  == 1234
+    assert createCycleID([1, 2, 3, 4], total=20) == 1020304
+    assert createCycleID([10, 2, 3, 4], total=20) == 10020304
+    assert createCycleID([10, 2, 3, 40], total=20) == 10020340
+    assert createCycleID([10, 20, 30, 4], total=20) == 10203004
+    assert createCycleID([10, 20, 30, 40], total=20) == 10203040


### PR DESCRIPTION
For that we reuse the cycle_id logic but we now generate a integer
instead of a string.

Example file: www.byte-physics.de/Downloads/H18.28.015.11.12.nwb.

Closes #102.