### PR TITLE
requirements.txt: Require latest pynwb version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,5 +9,5 @@ argschema
 allensdk
 dictdiffer
 pyabf==2.0.25
-pynwb>=0.5.1
+pynwb>=0.6.0
 six


### PR DESCRIPTION
We already require that since 13487580 (X-NWB/DATConverter/ABFConverter:
Add sweep numbers, 2018-11-08).

Closes #86.