### PR TITLE
requirements.txt: Raise required pynwb version to 0.6.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,5 +9,5 @@ argschema
 allensdk
 dictdiffer
 pyabf==2.0.25
-pynwb>=0.6.0
+pynwb>=0.6.2
 six


### PR DESCRIPTION
Only this version has the fix 6683635 (add list comprehension for
reading references in an array after file <80> (#740), 2018-11-19)
which is required for the SweepTable feature to be usable. This is used
in NwbXReader and now the tests pass.

Closes #123.