### PR TITLE
Fix issues arising from stimulus starting less than 500 ms after test pulse

### DIFF
--- a/ipfx/bin/run_pipeline.py
+++ b/ipfx/bin/run_pipeline.py
@@ -56,7 +56,7 @@ def main():
 
     """
     Usage:
-    python run_pipeline_extraction.py --input_json INPUT_JSON --output_json OUTPUT_JSON
+    python run_pipeline.py --input_json INPUT_JSON --output_json OUTPUT_JSON
 
     """
 

--- a/ipfx/plot_qc_figures.py
+++ b/ipfx/plot_qc_figures.py
@@ -160,11 +160,14 @@ def plot_sweep_figures(data_set, image_dir, sizes):
     b, a = sg.bessel(4, 0.1, "low")
 
     for i, sweep_number in enumerate(iclamp_sweep_numbers):
-        logging.info("plotting sweep %d" %  sweep_number)
 
+        logging.info("plotting sweep %d" % sweep_number)
 
         if i == 0:
             v_init, i_init, t_init, r_init, dt_init = load_sweep(data_set, sweep_number)
+
+            if r_init[0] <= 0:
+                r_init = (5000,r_init[1])
 
             tp_steps = r_init[0]
             tp_len = tp_steps*dt_init
@@ -198,6 +201,9 @@ def plot_sweep_figures(data_set, image_dir, sizes):
 
         else:
             v, i, t, r, dt = load_sweep(data_set, sweep_number)
+
+            if r[0] <= 0:       # This happens when stimulus starts less than 0.5 s after test pulse
+                r = (5000,r[1]) # Manually set start of experiment to a default positive value
 
             tp_steps = r[0]
             tp_len = tp_steps*dt
@@ -254,6 +260,7 @@ def plot_sweep_figures(data_set, image_dir, sizes):
         save_figure(exp_fig, 'experiment_%d' % sweep_number, 'experiments', image_dir, sizes, image_file_sets)
 
     return image_file_sets
+
 
 def save_figure(fig, image_name, image_set_name, image_dir, sizes, image_sets, scalew=1, scaleh=1, ext='png'):
     plt.figure(fig.number)

--- a/ipfx/qc_features.py
+++ b/ipfx/qc_features.py
@@ -362,7 +362,7 @@ def current_clamp_sweep_qc_features(sweep_data,sweep_info,ontology):
         sweep["vm_delta_mv"] = None
 
     # compute stimulus duration, amplitude, interval
-    stim_amp, stim_dur = stf.find_stim_amplitude_and_duration(expt_start_idx, current, hz)
+    _, stim_dur, stim_amp, _, _ = stf.get_stim_characteristics(current,t)
     stim_int = stf.find_stim_interval(expt_start_idx, current, hz)
 
     sweep['stimulus_amplitude'] = stim_amp

--- a/ipfx/stim_features.py
+++ b/ipfx/stim_features.py
@@ -187,21 +187,20 @@ def get_stim_characteristics(i, t, test_pulse=True):
     """
 
     di = np.diff(i)
-    diff_idx = np.flatnonzero(di)   # != 0
+    di_idx = np.flatnonzero(di)   # != 0
 
-    if len(diff_idx) == 0:
+    start_idx_idx = 2 if test_pulse else 0     # skip the first up/down (test pulse) if present
+
+    if len(di_idx[start_idx_idx:]) == 0:
         return None, None, 0.0, None, None
 
-    idx = 2 if test_pulse else 0     # skip the first up/down (test pulse) if present
-
-    # shift by one to compensate for diff()
-    start_idx = diff_idx[idx] + 1
-    end_idx = diff_idx[-1] + 1
+    start_idx = di_idx[start_idx_idx] + 1   # shift by one to compensate for diff()
+    end_idx = di_idx[-1]
 
     start_time = float(t[start_idx])
-    duration = float(t[end_idx] - t[start_idx])
+    duration = float(t[end_idx] - t[start_idx-1])
 
-    stim = i[start_idx:end_idx + 1]
+    stim = i[start_idx:end_idx+1]
 
     peak_high = max(stim)
     peak_low = min(stim)

--- a/ipfx/stim_features.py
+++ b/ipfx/stim_features.py
@@ -88,7 +88,8 @@ def get_sweep_epoch(response):
 
 def get_experiment_epoch(i,v,hz):
     """
-    Find index range for the experiment epoch. The start is defined as stim start- PRESTIM_DURATION*sampling_rate
+    Find index range for the experiment epoch.
+    The start index of the experiment epoch is defined as stim_start_idx - PRESTIM_DURATION*sampling_rate
     The end is defined by the last nonzero response.
 
 

--- a/ipfx/stim_features.py
+++ b/ipfx/stim_features.py
@@ -157,7 +157,6 @@ def find_stim_window(stim, idx0=0):
     return stim_start, stim_end - stim_start
 
 
-
 def find_stim_interval(idx0, stim, hz):
     stim = np.array(stim)[idx0:]
 
@@ -184,15 +183,14 @@ def find_stim_interval(idx0, stim, hz):
 
 def get_stim_characteristics(i, t, test_pulse=True):
     """
-    Identify the start time, duration, amplitude, start index, and
-    end index of a general stimulus.
+    Identify the start time, duration, amplitude, start index, and end index of a general stimulus.
     """
 
     di = np.diff(i)
-    diff_idx = np.flatnonzero(di)# != 0)
+    diff_idx = np.flatnonzero(di)   # != 0
 
     if len(diff_idx) == 0:
-        return (None, None, 0.0, None, None)
+        return None, None, 0.0, None, None
 
     idx = 2 if test_pulse else 0     # skip the first up/down (test pulse) if present
 
@@ -200,8 +198,8 @@ def get_stim_characteristics(i, t, test_pulse=True):
     start_idx = diff_idx[idx] + 1
     end_idx = diff_idx[-1] + 1
 
-    stim_start = float(t[start_idx])
-    stim_dur = float(t[end_idx] - t[start_idx])
+    start_time = float(t[start_idx])
+    duration = float(t[end_idx] - t[start_idx])
 
     stim = i[start_idx:end_idx + 1]
 
@@ -209,11 +207,11 @@ def get_stim_characteristics(i, t, test_pulse=True):
     peak_low = min(stim)
 
     if abs(peak_high) > abs(peak_low):
-        stim_amp = float(peak_high)
+        amplitude = float(peak_high)
     else:
-        stim_amp = float(peak_low)
+        amplitude = float(peak_low)
 
-    return stim_start, stim_dur, stim_amp, start_idx, end_idx
+    return start_time, duration, amplitude, start_idx, end_idx
 
 
 def _step_stim_amp(t, i, start):

--- a/tests/test_stim_features.py
+++ b/tests/test_stim_features.py
@@ -1,6 +1,5 @@
-import pytest
 import ipfx.stim_features as st
-
+import numpy as np
 
 
 def test_find_stim_start():
@@ -42,36 +41,89 @@ def test_find_stim_window():
     assert stim_start == 2
     assert stim_dur == 4
 
-def test_find_stim_amplitude_and_duration():
-    a = [0,1,1,0]
-    amp, dur = st.find_stim_amplitude_and_duration(0, a, hz=1)
-    assert amp == 1
-    assert dur == 2
 
-    a = [0,-2,-1,0]
-    amp, dur = st.find_stim_amplitude_and_duration(0, a, hz=1)
-    assert amp == -2
-    assert dur == 2
+def test_get_stim_characteristics():
 
-    a = [0,1,1,0,1,1,0]
-    amp, dur = st.find_stim_amplitude_and_duration(3, a, hz=1)
-    assert amp == 1
-    assert dur == 2
+    i = [0,1,1,0]
+    t = np.arange(len(i))
+    start_time, duration, amplitude, start_idx, end_idx = st.get_stim_characteristics(i, t, test_pulse=False)
+    assert start_time == 1
+    assert np.isclose(duration, 2)
+    assert np.isclose(amplitude,1)
+    assert start_idx == 1
+    assert end_idx == 2
 
-    a = [1,1,0,0,0,0,0]
-    amp, dur = st.find_stim_amplitude_and_duration(0, a, hz=1)
-    assert amp == 1
-    assert dur == 2
+    i = [0,0,1,1,0,0,3,3,3,3,0,0]
+    t = np.arange(len(i))
+    start_time, duration, amplitude, start_idx, end_idx = st.get_stim_characteristics(i, t)
+    assert start_time == 6
+    assert np.isclose(duration,4)
+    assert np.isclose(amplitude, 3)
+    assert start_idx == 6
+    assert end_idx == 9
 
-    a = [1,1,0,0,0,0,1]
-    amp, dur = st.find_stim_amplitude_and_duration(0, a, hz=1)
-    assert amp == 1
-    assert dur == 7
+    i = [0,0,-1,-1,0,0,3,3,3,3,0]
+    t = np.arange(len(i))
+    start_time, duration, amplitude, start_idx, end_idx = st.get_stim_characteristics(i, t)
+    assert start_time == 6
+    assert np.isclose(duration,4)
+    assert np.isclose(amplitude, 3)
+    assert start_idx == 6
+    assert end_idx == 9
 
-    a = [1,1,0,0,1,0,1]
-    amp, dur = st.find_stim_amplitude_and_duration(0, a, hz=1)
-    assert amp == 1
-    assert dur == 7
+    i = [0,0,-1,-1,0,0,-3,-3,-3,-3,0]
+    t = np.arange(len(i))
+    start_time, duration, amplitude, start_idx, end_idx = st.get_stim_characteristics(i, t)
+    assert start_time == 6
+    assert np.isclose(duration,4)
+    assert np.isclose(amplitude, -3)
+    assert start_idx == 6
+    assert end_idx == 9
+
+    i = [0,-2,-1,0]
+    t = np.arange(len(i))
+    start_time, duration, amplitude, start_idx, end_idx = st.get_stim_characteristics(i, t, test_pulse=False)
+    assert start_time == 1
+    assert np.isclose(duration,2)
+    assert np.isclose(amplitude, -2)
+    assert start_idx == 1
+    assert end_idx == 2
+
+    i = [0,1,1,0,1,1,0]
+    t = np.arange(len(i))
+    start_time, duration, amplitude, start_idx, end_idx = st.get_stim_characteristics(i, t)
+    assert start_time == 4
+    assert np.isclose(duration,2)
+    assert np.isclose(amplitude, 1)
+    assert start_idx == 4
+    assert end_idx == 5
+
+    i = [0,1,1,0,0,0,0,0]
+    t = np.arange(len(i))
+    start_time, duration, amplitude, start_idx, end_idx = st.get_stim_characteristics(i, t)
+    assert start_time == None
+    assert duration ==None
+    assert np.isclose(amplitude, 0)
+    assert start_idx == None
+    assert end_idx == None
+
+    i = [0,11,11,11,11,11,0,0,0,0,0]
+    t = np.arange(len(i))
+    start_time, duration, amplitude, start_idx, end_idx = st.get_stim_characteristics(i, t,test_pulse=False)
+    assert start_time == 1
+    assert np.isclose(duration,5)
+    assert np.isclose(amplitude, 11)
+    assert start_idx == 1
+    assert end_idx == 5
+
+    i = [0,0,1,1,0,0,0.1,0.2,0.3,0.4,0.5,0.6,0.7,0,0]
+    t = np.arange(len(i))
+    start_time, duration, amplitude, start_idx, end_idx = st.get_stim_characteristics(i, t)
+    assert start_time == 6
+    assert np.isclose(duration,7)
+    assert np.isclose(amplitude, 0.7)
+    assert start_idx == 6
+    assert end_idx == 12
 
 def test_find_stim_interval():
     a = [0,1,0,1,0,1,0]


### PR DESCRIPTION
Avoid using experiment epoch start index to determine stimuli properties because it takes negative values for the stimuli starting less than 500 ms after test pulse. 
Stop using experiment epoch start index for the plotting, rather use a hard coded value.
Improve get_stim_characterists function