### PR TITLE
NwbReader.get_sweep_number: Return the real sweep number

### DIFF
--- a/ipfx/nwb_reader.py
+++ b/ipfx/nwb_reader.py
@@ -45,33 +45,42 @@ class NwbReader(object):
         else:
             raise ValueError("Unit {} not recognized from TimeSeries".format(unit))
 
-    @staticmethod
-    def check_sweep_number(timeseries, sweep_number):
+    def get_real_sweep_number(self, sweep_name, assumed_sweep_number=None):
         """
-        Check if the assumed sweep number is the same than the real sweep number.
+        Return the real sweep number for the given sweep_name. Falls back to
+        assumed_sweep_number if given.
         """
 
-        real_sweep_number = None
+        with h5py.File(self.nwb_file, 'r') as f:
+            timeseries = f[self.acquisition_path][sweep_name]
 
-        def read_sweep_from_source(source):
-            source = get_scalar_string(source)
-            for x in source.split(";"):
-                result = re.search(r"^Sweep=(\d+)$", x)
-                if result:
-                    return int(result.group(1))
+            real_sweep_number = None
 
-        if "source" in timeseries:
-            real_sweep_number = read_sweep_from_source(timeseries["source"].value)
-        elif "source" in timeseries.attrs:
-            real_sweep_number = read_sweep_from_source(timeseries.attrs["source"])
-        elif "sweep_number" in timeseries.attrs:
-            real_sweep_number = timeseries.attrs["sweep_number"]
+            def read_sweep_from_source(source):
+                source = get_scalar_string(source)
+                for x in source.split(";"):
+                    result = re.search(r"^Sweep=(\d+)$", x)
+                    if result:
+                        return int(result.group(1))
 
-        if real_sweep_number is None:
-            warnings.warn("Could not find a source/sweep_number attribute/dataset.")
-        elif real_sweep_number != sweep_number:
-            raise ValueError("Sweep number mismatch with timeseries {} ({} vs {}).".format(
-                             timeseries, sweep_number, real_sweep_number))
+            if "source" in timeseries:
+                real_sweep_number = read_sweep_from_source(timeseries["source"].value)
+            elif "source" in timeseries.attrs:
+                real_sweep_number = read_sweep_from_source(timeseries.attrs["source"])
+            elif "sweep_number" in timeseries.attrs:
+                real_sweep_number = timeseries.attrs["sweep_number"]
+
+        if assumed_sweep_number is not None and assumed_sweep_number != real_sweep_number:
+            warnings.warn("Sweep number mismatch (real: {} vs assumed: {}"
+                          " in file {}".format(real_sweep_number,
+                                               assumed_sweep_number, self.nwb_file))
+
+        if real_sweep_number is not None:
+            return real_sweep_number
+        elif assumed_sweep_number is not None:
+            return assumed_sweep_number
+
+        raise ValueError("Could not find a source/sweep_number attribute/dataset.")
 
     def get_sweep_attrs(self, sweep_name):
 
@@ -139,7 +148,7 @@ class NwbXReader(NwbReader):
         self.nwb_major_version = 2
 
     def get_sweep_number(self, sweep_name):
-        return self.get_sweep_attrs(sweep_name)["sweep_number"]
+        return self.get_real_sweep_number(sweep_name)
 
     def get_stim_code(self, sweep_name):
         return self.get_sweep_attrs(sweep_name)["stimulus_description"]
@@ -264,7 +273,6 @@ class NwbPipelineReader(NwbReader):
             swp = f['epochs'][sweep_name]
 
             sweep_ts = f[self.acquisition_path][sweep_name]
-            NwbReader.check_sweep_number(sweep_ts, sweep_number)
 
             #   fetch data from file and convert to correct SI unit
             #   this operation depends on file version. early versions of
@@ -339,8 +347,8 @@ class NwbPipelineReader(NwbReader):
 
     def get_sweep_number(self, sweep_name):
 
-        sweep_number = int(sweep_name.split('_')[-1])
-        return sweep_number
+        assumed_sweep_number = int(sweep_name.split('_')[-1])
+        return self.get_real_sweep_number(sweep_name, assumed_sweep_number)
 
     def get_stim_code(self, sweep_name):
 
@@ -376,11 +384,9 @@ class NwbMiesReader(NwbReader):
 
         with h5py.File(self.nwb_file, 'r') as f:
             sweep_response = f[self.acquisition_path]["data_%05d_AD0" % sweep_number]
-            self.check_sweep_number(sweep_response, sweep_number)
             response_dataset = sweep_response["data"]
             hz = 1.0 * sweep_response["starting_time"].attrs['rate']
             sweep_stimulus = f[self.stimulus_path]["data_%05d_DA0" % sweep_number]
-            self.check_sweep_number(sweep_stimulus, sweep_number)
             stimulus_dataset = sweep_stimulus["data"]
 
             response = response_dataset.value
@@ -410,9 +416,8 @@ class NwbMiesReader(NwbReader):
 
     def get_sweep_number(self, sweep_name):
 
-        sweep_number = int(sweep_name.split('_')[1])
-
-        return sweep_number
+        assumed_sweep_number = int(sweep_name.split('_')[1])
+        return self.get_real_sweep_number(sweep_name, assumed_sweep_number)
 
     def get_stim_code(self, sweep_name):
 

--- a/tests/fetch_file.py
+++ b/tests/fetch_file.py
@@ -1,0 +1,30 @@
+import os
+import urllib2
+import shutil
+from allensdk.api.queries.cell_types_api import CellTypesApi
+
+
+def get_celltypes_file(folder, specimen_id):
+    nwb_file = '{}.nwb'.format(specimen_id)
+
+    file_path = os.path.join(folder, nwb_file)
+
+    if not os.path.exists(file_path):
+        ct = CellTypesApi()
+        ct.save_ephys_data(specimen_id, file_path)
+
+    return file_path
+
+
+def fetch_test_file(folder, nwb_file):
+    file_path = os.path.join(folder, nwb_file)
+
+    if not os.path.exists(file_path):
+
+        BASE_URL = "https://www.byte-physics.de/Downloads/allensdk-test-data/"
+
+        response = urllib2.urlopen(BASE_URL + nwb_file)
+        with open(file_path, "wb") as out_file:
+            shutil.copyfileobj(response, out_file)
+
+    return file_path

--- a/tests/test_hbg_dataset.py
+++ b/tests/test_hbg_dataset.py
@@ -6,7 +6,7 @@ import shutil
 from ipfx.stimulus import StimulusOntology
 from ipfx.hbg_dataset import HBGDataSet
 
-from helpers import compare_dicts
+from helpers_for_tests import compare_dicts
 
 
 @pytest.fixture()

--- a/tests/test_nwb_reader.py
+++ b/tests/test_nwb_reader.py
@@ -1,36 +1,22 @@
 import os
-import urllib2
-import shutil
-
 import pytest
 
 import h5py
 import numpy as np
 
 from ipfx.nwb_reader import create_nwb_reader, NwbMiesReader, NwbPipelineReader, NwbXReader
-from allensdk.api.queries.cell_types_api import CellTypesApi
 from helpers_for_tests import compare_dicts
+from fetch_file import get_celltypes_file, fetch_test_file
 
 
 @pytest.fixture()
 def fetch_pipeline_file():
-    specimen_id = 595570553
-    nwb_file = '{}.nwb'.format(specimen_id)
-    if not os.path.exists(nwb_file):
-        ct = CellTypesApi()
-        ct.save_ephys_data(specimen_id, nwb_file)
+    return get_celltypes_file(".", 595570553)
 
 
 @pytest.fixture()
 def fetch_DAT_NWB_file():
-    output_filepath = 'H18.28.015.11.14.nwb'
-    if not os.path.exists(output_filepath):
-
-        BASE_URL = "https://www.byte-physics.de/Downloads/allensdk-test-data/"
-
-        response = urllib2.urlopen(BASE_URL + output_filepath)
-        with open(output_filepath, "wb") as out_file:
-            shutil.copyfileobj(response, out_file)
+    return fetch_test_file(".", 'H18.28.015.11.14.nwb')
 
 
 def test_raises_on_missing_file():
@@ -98,7 +84,7 @@ def test_valid_v1_skeleton_X_NWB():
 
 
 def test_valid_v1_full_Pipeline(fetch_pipeline_file):
-    reader = create_nwb_reader('595570553.nwb')
+    reader = create_nwb_reader(fetch_pipeline_file)
     assert isinstance(reader, NwbPipelineReader)
 
     sweep_names_ref = [u'Sweep_10',
@@ -376,7 +362,7 @@ def test_valid_v2_full_ABF():
 
 def test_valid_v2_full_DAT(fetch_DAT_NWB_file):
 
-    reader = create_nwb_reader('H18.28.015.11.14.nwb')
+    reader = create_nwb_reader(fetch_DAT_NWB_file)
     assert isinstance(reader, NwbXReader)
 
     sweep_names_ref = ['index_{:02d}'.format(x) for x in range(0, 78)]

--- a/tests/test_nwb_reader.py
+++ b/tests/test_nwb_reader.py
@@ -19,6 +19,11 @@ def fetch_DAT_NWB_file():
     return fetch_test_file(".", 'H18.28.015.11.14.nwb')
 
 
+@pytest.fixture()
+def fetch_missing_sweep_number_files():
+    return [fetch_test_file(".", x) for x in ["500844779.nwb", "509604657.nwb"]]
+
+
 def test_raises_on_missing_file():
     with pytest.raises(IOError):
         create_nwb_reader('I_DONT_EXIST.nwb')
@@ -81,6 +86,16 @@ def test_valid_v1_skeleton_X_NWB():
 
     reader = create_nwb_reader(filename)
     assert isinstance(reader, NwbXReader)
+
+
+def test_assumed_sweep_number_fallback(fetch_missing_sweep_number_files):
+
+    for x in fetch_missing_sweep_number_files:
+        reader = create_nwb_reader(x)
+        assert isinstance(reader, NwbPipelineReader)
+
+        with pytest.warns(UserWarning, match="Sweep number mismatch"):
+            assert reader.get_sweep_number("Sweep_10") == 10
 
 
 def test_valid_v1_full_Pipeline(fetch_pipeline_file):


### PR DESCRIPTION
In 44ea93e7 (NwbReader: Check that the assumed and the real sweep number
are the same, 2018-12-06) we added code to check that the assumed sweep
number is the same as the real sweep number.

But we can be better than that and just return the real sweep number if
requested.

Close #111.