### PR TITLE
X-NWB/nwb_to_pdf.py: Limit plotting range to the minimum number of points

### DIFF
--- a/ipfx/bin/nwb_to_pdf.py
+++ b/ipfx/bin/nwb_to_pdf.py
@@ -267,7 +267,7 @@ def plot_sweepdata(sweepdata, axes, addXTicks=False):
         axes:      np.ndarray(plt.axis)
         addXTicks: Add ticks and a label to the X axis at the bottom
     '''
-    length = len(sweepdata.items())
+    numItems = len(sweepdata.items())
 
     for index, pcs_data_plot in enumerate(sweepdata.values()):
         plot_patchClampSeries(axes[index], pcs_data_plot)
@@ -277,7 +277,7 @@ def plot_sweepdata(sweepdata, axes, addXTicks=False):
                                                 pcs_data_plot.unit['x']))
             axes[index].xaxis.set_tick_params(labelbottom=True)
 
-    for axis in axes[length:]:
+    for axis in axes[numItems:]:
         axis.remove()
 
 

--- a/ipfx/bin/nwb_to_pdf.py
+++ b/ipfx/bin/nwb_to_pdf.py
@@ -240,13 +240,14 @@ def gather_sweeps(nwbfile):
     return sweeps
 
 
-def plot_patchClampSeries(axis, pcs_data_plot):
+def plot_patchClampSeries(axis, pcs_data_plot, length):
     '''
     plot a PatchClampSeries against the axis
         pcs_data_plot: class PatchClampSeriesPlotData
         axis:    plt.axis
+        length:  number of points to plot
     '''
-    axis.plot(pcs_data_plot.data['x'], pcs_data_plot.data['y'])
+    axis.plot(pcs_data_plot.data['x'][:length - 1], pcs_data_plot.data['y'][:length-1])
     axis.set_title("%s" % pcs_data_plot.title)
     axis.set_ylabel('%s [%s]' % (pcs_data_plot.axis['y'],
                                  pcs_data_plot.unit['y']))
@@ -259,18 +260,19 @@ def plot_patchClampSeries(axis, pcs_data_plot):
               bbox=props)
 
 
-def plot_sweepdata(sweepdata, axes, addXTicks=False):
+def plot_sweepdata(sweepdata, axes, length, addXTicks=False):
     '''
     plot the given sweep data (stimulus or acquisition) on the given axes
         sweepdata: dict(class PatchClampSeriesPlotData) (either acquisition or
                    stimulus)
         axes:      np.ndarray(plt.axis)
+        length:    number of points to plot
         addXTicks: Add ticks and a label to the X axis at the bottom
     '''
     numItems = len(sweepdata.items())
 
     for index, pcs_data_plot in enumerate(sweepdata.values()):
-        plot_patchClampSeries(axes[index], pcs_data_plot)
+        plot_patchClampSeries(axes[index], pcs_data_plot, length)
 
         if addXTicks:
             axes[index].set_xlabel('%s [%s]' % (pcs_data_plot.axis['x'],
@@ -388,6 +390,12 @@ def create_regular_pdf(nwbfile, outfile):
 
     sweeps = gather_sweeps(nwbfile)
 
+    def min_length(sweepdata, length):
+        for pcs_data_plot in sweepdata.values():
+            length = min(length, len(pcs_data_plot.data['y']))
+
+        return length
+
     with PdfPages(outfile) as pdf:
         for cycle_id in sweeps:
             sweep = sweeps.get(cycle_id)
@@ -399,8 +407,11 @@ def create_regular_pdf(nwbfile, outfile):
             fig, axes = plt.subplots(nrows=2, ncols=ncols, sharex='row',
                                      num=cycle_id, squeeze=False)
 
-            plot_sweepdata(sweep.get_stimulus(), axes[0][:])
-            plot_sweepdata(sweep.get_acquisition(), axes[1][:], addXTicks=True)
+            length = min_length(sweep.get_stimulus(), math.inf)
+            length = min_length(sweep.get_acquisition(), length)
+
+            plot_sweepdata(sweep.get_stimulus(), axes[0][:], length)
+            plot_sweepdata(sweep.get_acquisition(), axes[1][:], length, addXTicks=True)
 
             fig.suptitle("Sweep %s" % cycle_id)
             fig.set_size_inches(8.27, 11.69)  # a4 portrait

--- a/ipfx/bin/nwb_to_pdf.py
+++ b/ipfx/bin/nwb_to_pdf.py
@@ -176,6 +176,8 @@ class PatchClampSeriesPlotData():
 
     def _annotation(self, pcs):
         self.annotation = []
+        description = json.loads(pcs.description)
+        self.add_annotation("file", description.get("file", "NA"), None)
         self.add_annotation("desc", pcs.stimulus_description, None)
         self.add_annotation("rate", pcs.rate, "Hz")
         self.add_annotation("gain", pcs.gain, "x")

--- a/ipfx/x_to_nwb/ABFConverter.py
+++ b/ipfx/x_to_nwb/ABFConverter.py
@@ -353,7 +353,8 @@ class ABFConverter:
             settings = self._amplifierSettings[amplifier]
 
             if settings["GetMode"] != clampMode:
-                warnings.warn("Stored clamp mode {settings['GetMode']} does not match requested clamp mode {clampMode}")
+                warnings.warn(f"Stored clamp mode {settings['GetMode']} does not match requested "
+                              f"clamp mode {clampMode} of channel {adcName}.")
                 settings = None
         except (TypeError, KeyError) as e:
             warnings.warn(f"Could not find settings for amplifier of channel {adcName}.")

--- a/ipfx/x_to_nwb/ABFConverter.py
+++ b/ipfx/x_to_nwb/ABFConverter.py
@@ -312,6 +312,7 @@ class ABFConverter:
                     gain = abf._dacSection.fDACScaleFactor[channel]
                     resolution = np.nan
                     starting_time = self._calculateStartingTime(abf)
+                    stimulus_description = abf.protocol
                     rate = float(abf.dataRate)
                     description = json.dumps({"cycle_id": cycle_id,
                                               "protocol": abf.protocol,
@@ -332,7 +333,8 @@ class ABFConverter:
                                            conversion=conversion,
                                            starting_time=starting_time,
                                            rate=rate,
-                                           description=description)
+                                           description=description,
+                                           stimulus_description=stimulus_description)
 
                     series.append(stimulus)
 

--- a/ipfx/x_to_nwb/ABFConverter.py
+++ b/ipfx/x_to_nwb/ABFConverter.py
@@ -317,6 +317,7 @@ class ABFConverter:
                     description = json.dumps({"cycle_id": cycle_id,
                                               "protocol": abf.protocol,
                                               "protocolPath": abf.protocolPath,
+                                              "file": os.path.basename(abf.abfFilePath),
                                               "name": abf.dacNames[channel],
                                               "number": abf._dacSection.nDACNum[channel]},
                                              sort_keys=True, indent=4)
@@ -452,6 +453,7 @@ class ABFConverter:
                     description = json.dumps({"cycle_id": cycle_id,
                                               "protocol": abf.protocol,
                                               "protocolPath": abf.protocolPath,
+                                              "file": os.path.basename(abf.abfFilePath),
                                               "name": adcName,
                                               "number": abf._adcSection.nADCNum[channel]},
                                              sort_keys=True, indent=4)

--- a/ipfx/x_to_nwb/DatConverter.py
+++ b/ipfx/x_to_nwb/DatConverter.py
@@ -280,7 +280,9 @@ class DatConverter:
                         stimulus_description = series.Label
                         starting_time = (self._convertTimestamp(sweep.Time) - self.session_start_time).total_seconds()
                         rate = 1.0 / stimRec.SampleInterval
-                        description = json.dumps({"cycle_id": cycle_id}, sort_keys=True, indent=4)
+                        description = json.dumps({"cycle_id": cycle_id,
+                                                  "file": os.path.basename(self.bundle.file_name)},
+                                                 sort_keys=True, indent=4)
 
                         channelRec_index = getChannelRecordIndex(self.bundle.pgf, sweep, trace)
                         assert channelRec_index is not None, "Unexpected channel record index"
@@ -358,7 +360,9 @@ class DatConverter:
                         resolution = np.nan
                         starting_time = (self._convertTimestamp(sweep.Time) - self.session_start_time).total_seconds()
                         rate = 1.0 / trace.XInterval
-                        description = json.dumps({"cycle_id": cycle_id}, sort_keys=True, indent=4)
+                        description = json.dumps({"cycle_id": cycle_id,
+                                                  "file": os.path.basename(self.bundle.file_name)},
+                                                 sort_keys=True, indent=4)
                         clampMode = self._getClampMode(trace)
                         seriesClass = getAcquiredSeriesClass(clampMode)
                         stimulus_description = series.Label

--- a/ipfx/x_to_nwb/hr_bundle.py
+++ b/ipfx/x_to_nwb/hr_bundle.py
@@ -47,7 +47,7 @@ class Bundle():
                 ext = item.Extension
                 self.catalog[ext] = item
 
-            if not self.header.Version.startswith("v2x90.1"):
+            if not self.header.Version.startswith("v2x90"):
                 warnings.warn(f"The DAT file version '{self.header.Version}' of '{file_name}' might "
                               "be incompatible and therefore read/interpretation errors are possible.")
 


### PR DESCRIPTION
For some ABF files the length of the stimset differs from the acquired
channels. This creates a wrong axis scaling as the plotting uses
constant size of the graphs.

Restrict the range to the minimum length to avoid that issue.