### PR TITLE
Fix bugs in stim start

### DIFF
--- a/ipfx/epochs.py
+++ b/ipfx/epochs.py
@@ -1,0 +1,132 @@
+import numpy as np
+import time_series_utils as tsu
+
+
+# global constants
+#TODO: read them from the config file
+
+NOISE_EPOCH = 0.0015
+PRESTIM_STABILITY_EPOCH = 0.5
+POSTSTIM_STABILITY_EPOCH = 0.5
+LONG_RESPONSE_DURATION = 5  # this will count long ramps as completed
+
+
+def get_last_vm_epoch(idx1, hz):
+    """
+    Get epoch lasting LAST_STABILITY_EPOCH before the end of recording
+
+    Parameters
+    ----------
+    idx1
+    hz
+
+    Returns
+    -------
+
+    """
+    return idx1-int(POSTSTIM_STABILITY_EPOCH * hz), idx1
+
+
+def get_first_vm_noise_epoch(idx, hz):
+
+    return idx, idx + int(NOISE_EPOCH * hz)
+
+
+def get_last_vm_noise_epoch(idx1, hz):
+
+    return idx1-int(NOISE_EPOCH * hz), idx1
+
+
+def get_stability_vm_epoch(stim_start, hz):
+    num_steps = int(PRESTIM_STABILITY_EPOCH * hz)
+    if num_steps > stim_start-1:
+        num_steps = stim_start-1
+    elif num_steps <= 0:
+        return 0, 0
+    assert num_steps > 0, "Number of steps should be a positive integer"
+
+    return stim_start-1-num_steps, stim_start-1
+
+
+def get_recording_end_idx(v):
+
+    end_idx = np.nonzero(v)[0][-1]  # last non-zero index along the only dimension=0.
+    return end_idx
+
+def get_sweep_epoch(response):
+
+    sweep_end_idx = np.nonzero(response)[0][-1]  # last non-zero index along the only dimension=0.
+
+    return (0, sweep_end_idx)
+
+def get_experiment_epoch(i,v,hz):
+    """
+    Find index range for the experiment epoch.
+    The start index of the experiment epoch is defined as stim_start_idx - PRESTIM_DURATION*sampling_rate
+    The end is defined by the last nonzero response.
+
+
+    Parameters
+    ----------
+    i : stimulus
+    v : response
+    hz: sampling rate
+
+    Returns
+    -------
+    start and end indices
+
+    """
+    # TODO: deal with non iclamp sweeps and non experimental sweeps
+    di = np.diff(i)
+    diff_idx = np.flatnonzero(di)  # != 0)
+
+    if len(diff_idx) == 0:
+        raise ValueError("Empty stimulus trace")
+    if len(diff_idx) >= 4:
+        idx = 2  # skip the first up/down assuming that there is a test pulse
+    else:
+        idx = 0
+
+    stim_start_idx = diff_idx[idx] + 1  # shift by one to compensate for diff()
+    expt_start_idx = stim_start_idx - int(PRESTIM_STABILITY_EPOCH * hz)
+    #       Recording ends when zeros start
+    expt_end_idx = np.nonzero(v)[0][-1]  # last non-zero index along the only dimension=0.
+
+    return expt_start_idx,expt_end_idx
+
+
+def find_stim_window(stim, idx0=0):
+    """
+    Find the index of the first nonzero positive or negative jump in an array and the number of timesteps until the last such jump.
+
+    Parameters
+    ----------
+    stim: np.ndarray
+        Array to be searched
+
+    idx0: int
+        Start searching with this index (default: 0).
+
+    Returns
+    -------
+    start_index, duration
+    """
+
+    di = np.diff(stim)
+    idxs = np.flatnonzero(di)
+    idxs = idxs[idxs >= idx0]
+
+    if len(idxs) == 0:
+        return -1, 0
+
+    stim_start = idxs[0]+1
+
+    if len(idxs) == 1:
+        return stim_start, len(stim)-stim_start
+
+    stim_end = idxs[-1]+1
+
+    return stim_start, stim_end - stim_start
+
+

--- a/ipfx/epochs.py
+++ b/ipfx/epochs.py
@@ -50,12 +50,12 @@ def get_stability_vm_epoch(stim_start, hz):
 
 def get_recording_end_idx(v):
 
-    end_idx = np.nonzero(v)[0][-1]  # last non-zero index along the only dimension=0.
+    end_idx = np.flatnonzero(v)[-1]  # last non-zero index along the only dimension=0.
     return end_idx
 
 def get_sweep_epoch(response):
 
-    sweep_end_idx = np.nonzero(response)[0][-1]  # last non-zero index along the only dimension=0.
+    sweep_end_idx = np.flatnonzero(response)[-1]  # last non-zero index along the only dimension=0.
 
     return (0, sweep_end_idx)
 

--- a/ipfx/nwb_reader.py
+++ b/ipfx/nwb_reader.py
@@ -1,5 +1,4 @@
 import re
-import json
 import warnings
 
 import h5py
@@ -8,7 +7,7 @@ from pynwb import NWBHDF5IO
 from pynwb.icephys import (CurrentClampSeries, CurrentClampStimulusSeries, VoltageClampSeries,
                            VoltageClampStimulusSeries, IZeroClampSeries)
 
-import ipfx.stim_features as st
+import ipfx.epochs as ep
 
 
 def get_scalar_string(string_from_nwb):
@@ -396,9 +395,9 @@ class NwbMiesReader(NwbReader):
                 unit_str = 'Unknown'
 
             if "CurrentClampSeries" in sweep_response.attrs["ancestry"]:
-                index_range = st.get_experiment_epoch(stimulus, response, hz)
+                index_range = ep.get_experiment_epoch(stimulus, response, hz)
             elif "VoltageClampSeries" in sweep_response.attrs["ancestry"]:
-                index_range = st.get_sweep_epoch(response)
+                index_range = ep.get_sweep_epoch(response)
             else:
                 raise ValueError("Unknown Clamp Mode")
 

--- a/ipfx/qc_features.py
+++ b/ipfx/qc_features.py
@@ -351,7 +351,6 @@ def current_clamp_sweep_qc_features(sweep_data,sweep_info,ontology):
     sweep["slow_vm_mv"] = float(mean2)
     sweep["slow_noise_rms_mv"] = float(rms2)
 
-    # for now (mid-feb 15), make vm_mv the same for pre and slow
     mean0 = mean2
     sweep["pre_vm_mv"] = float(mean0)
 
@@ -362,8 +361,6 @@ def current_clamp_sweep_qc_features(sweep_data,sweep_info,ontology):
         # Use None as 'nan' still breaks the ruby strategies
         sweep["vm_delta_mv"] = None
 
-    # compute stimulus duration, amplitude, interval
-    _, stim_dur, stim_amp, _, _ = stf.get_stim_characteristics(current,t)
     stim_int = stf.find_stim_interval(expt_start_idx, current, hz)
 
     sweep['stimulus_amplitude'] = stim_amp
@@ -393,14 +390,12 @@ def sweep_completed(i,v,t,hz):
     post_stim_response_duration = (response_end_ix - stimulus_end_ix) / hz
     completed_expt_epoch = post_stim_response_duration > POSTSTIM_STABILITY_EPOCH
 
-    long_response = response_end_ix/hz>LONG_RESPONSE_DURATION
+    long_response = (response_end_ix / hz) > LONG_RESPONSE_DURATION
 
     if completed_expt_epoch or long_response:
         return True
     else:
         return False
-
-    return sweep_completion
 
 
 

--- a/ipfx/qc_features.py
+++ b/ipfx/qc_features.py
@@ -1,4 +1,5 @@
 from . import stim_features as stf
+from . import epochs as ep
 from . import error as er
 import logging
 import numpy as np
@@ -316,7 +317,7 @@ def current_clamp_sweep_qc_features(sweep_data,sweep_info,ontology):
     expt_start_idx, expt_end_idx = sweep_data.expt_idx_range
 
     # measure Vm and noise before stimulus
-    idx0, idx1 = stf.get_first_vm_noise_epoch(expt_start_idx, hz)  # count from the beginning of the experiment
+    idx0, idx1 = ep.get_first_vm_noise_epoch(expt_start_idx, hz)  # count from the beginning of the experiment
 
     _, rms0 = measure_vm(voltage[idx0:idx1])
 
@@ -329,9 +330,9 @@ def current_clamp_sweep_qc_features(sweep_data,sweep_info,ontology):
     is_ramp = sweep_info['stimulus_name'] in ontology.ramp_names
 
     if not is_ramp:
-        idx0, idx1 = stf.get_last_vm_epoch(expt_end_idx, hz)
+        idx0, idx1 = ep.get_last_vm_epoch(expt_end_idx, hz)
         mean_last_vm_epoch, _ = measure_vm(voltage[idx0:idx1])
-        idx0, idx1 = stf.get_last_vm_noise_epoch(expt_end_idx, hz)
+        idx0, idx1 = ep.get_last_vm_noise_epoch(expt_end_idx, hz)
         _, rms1 = measure_vm(voltage[idx0:idx1])
         sweep["post_vm_mv"] = float(mean_last_vm_epoch)
         sweep["post_noise_rms_mv"] = float(rms1)
@@ -344,7 +345,7 @@ def current_clamp_sweep_qc_features(sweep_data,sweep_info,ontology):
 
     sweep['stimulus_start_time'] = stim_start_time
 
-    idx0, idx1 = stf.get_stability_vm_epoch(stim_start_idx, hz)
+    idx0, idx1 = ep.get_stability_vm_epoch(stim_start_idx, hz)
     mean2, rms2 = measure_vm(voltage[idx0:idx1])
 
     sweep["slow_vm_mv"] = float(mean2)
@@ -384,7 +385,7 @@ def sweep_completed(i,v,t,hz):
         return False
 
     stim_start_time, stim_duration, stim_amplitude, stim_start_idx, stim_end_idx = stf.get_stim_characteristics(i,t)
-    expt_start_ix, expt_end_ix = stf.get_experiment_epoch(i, v, hz)
+    expt_start_ix, expt_end_ix = ep.get_experiment_epoch(i, v, hz)
 
     stimulus_end_ix = stim_end_idx
     response_end_ix = expt_end_ix

--- a/ipfx/stim_features.py
+++ b/ipfx/stim_features.py
@@ -2,158 +2,6 @@ import numpy as np
 import time_series_utils as tsu
 
 
-# global constants
-#TODO: read them from the config file
-
-NOISE_EPOCH = 0.0015
-PRESTIM_STABILITY_EPOCH = 0.5
-POSTSTIM_STABILITY_EPOCH = 0.5
-LONG_RESPONSE_DURATION = 5  # this will count long ramps as completed
-
-
-def get_last_vm_epoch(idx1, hz):
-    """
-    Get epoch lasting LAST_STABILITY_EPOCH before the end of recording
-
-    Parameters
-    ----------
-    idx1
-    hz
-
-    Returns
-    -------
-
-    """
-    return idx1-int(POSTSTIM_STABILITY_EPOCH * hz), idx1
-
-
-def get_first_vm_noise_epoch(idx, hz):
-
-    return idx, idx + int(NOISE_EPOCH * hz)
-
-
-def get_last_vm_noise_epoch(idx1, hz):
-
-    return idx1-int(NOISE_EPOCH * hz), idx1
-
-
-def get_stability_vm_epoch(stim_start, hz):
-    num_steps = int(PRESTIM_STABILITY_EPOCH * hz)
-    if num_steps > stim_start-1:
-        num_steps = stim_start-1
-    elif num_steps <= 0:
-        return 0, 0
-    assert num_steps > 0, "Number of steps should be a positive integer"
-
-    return stim_start-1-num_steps, stim_start-1
-
-
-def get_recording_end_idx(v):
-
-    end_idx = np.nonzero(v)[0][-1]  # last non-zero index along the only dimension=0.
-    return end_idx
-
-def get_sweep_epoch(response):
-
-    sweep_end_idx = np.nonzero(response)[0][-1]  # last non-zero index along the only dimension=0.
-
-    return (0, sweep_end_idx)
-
-def get_experiment_epoch(i,v,hz):
-    """
-    Find index range for the experiment epoch.
-    The start index of the experiment epoch is defined as stim_start_idx - PRESTIM_DURATION*sampling_rate
-    The end is defined by the last nonzero response.
-
-
-    Parameters
-    ----------
-    i : stimulus
-    v : response
-    hz: sampling rate
-
-    Returns
-    -------
-    start and end indices
-
-    """
-    # TODO: deal with non iclamp sweeps and non experimental sweeps
-    di = np.diff(i)
-    diff_idx = np.flatnonzero(di)  # != 0)
-
-    if len(diff_idx) == 0:
-        raise ValueError("Empty stimulus trace")
-    if len(diff_idx) >= 4:
-        idx = 2  # skip the first up/down assuming that there is a test pulse
-    else:
-        idx = 0
-
-    stim_start_idx = diff_idx[idx] + 1  # shift by one to compensate for diff()
-    expt_start_idx = stim_start_idx - int(PRESTIM_STABILITY_EPOCH * hz)
-    #       Recording ends when zeros start
-    expt_end_idx = np.nonzero(v)[0][-1]  # last non-zero index along the only dimension=0.
-
-    return expt_start_idx,expt_end_idx
-
-
-def find_stim_window(stim, idx0=0):
-    """
-    Find the index of the first nonzero positive or negative jump in an array and the number of timesteps until the last such jump.
-
-    Parameters
-    ----------
-    stim: np.ndarray
-        Array to be searched
-
-    idx0: int
-        Start searching with this index (default: 0).
-
-    Returns
-    -------
-    start_index, duration
-    """
-
-    di = np.diff(stim)
-    idxs = np.flatnonzero(di)
-    idxs = idxs[idxs >= idx0]
-
-    if len(idxs) == 0:
-        return -1, 0
-
-    stim_start = idxs[0]+1
-
-    if len(idxs) == 1:
-        return stim_start, len(stim)-stim_start
-
-    stim_end = idxs[-1]+1
-
-    return stim_start, stim_end - stim_start
-
-
-def find_stim_interval(idx0, stim, hz):
-    stim = np.array(stim)[idx0:]
-
-    # indices where is the stimulus off
-    zero_idxs = np.where(stim == 0)[0]
-
-    # derivative of off indices.  when greater than one, indicates on period
-    dzero_idxs = np.diff(zero_idxs)
-    dzero_break_idxs = np.where(dzero_idxs[:] > 1)[0]
-
-    # duration of breaks
-    break_durs = dzero_idxs[dzero_break_idxs]
-
-    # indices of breaks
-    break_idxs = zero_idxs[dzero_break_idxs] + 1
-
-    # time between break onsets
-    dbreaks = np.diff(break_idxs)
-    if len(np.unique(break_durs)) == 1 and len(np.unique(dbreaks)) == 1:
-        return dbreaks[0] / hz
-
-    return None
-
-
 def get_stim_characteristics(i, t, test_pulse=True):
     """
     Identify the start time, duration, amplitude, start index, and end index of a general stimulus.
@@ -193,3 +41,26 @@ def _step_stim_amp(t, i, start):
 def _short_step_stim_amp(t, i, start):
     t_index = tsu.find_time_index(t, start)
     return i[t_index + 1:].max()
+
+def find_stim_interval(idx0, stim, hz):
+    stim = np.array(stim)[idx0:]
+
+    # indices where is the stimulus off
+    zero_idxs = np.where(stim == 0)[0]
+
+    # derivative of off indices.  when greater than one, indicates on period
+    dzero_idxs = np.diff(zero_idxs)
+    dzero_break_idxs = np.where(dzero_idxs[:] > 1)[0]
+
+    # duration of breaks
+    break_durs = dzero_idxs[dzero_break_idxs]
+
+    # indices of breaks
+    break_idxs = zero_idxs[dzero_break_idxs] + 1
+
+    # time between break onsets
+    dbreaks = np.diff(break_idxs)
+    if len(np.unique(break_durs)) == 1 and len(np.unique(dbreaks)) == 1:
+        return dbreaks[0] / hz
+
+    return None

--- a/ipfx/stim_features.py
+++ b/ipfx/stim_features.py
@@ -48,33 +48,6 @@ def get_stability_vm_epoch(stim_start, hz):
     return stim_start-1-num_steps, stim_start-1
 
 
-def find_stim_start(stim, idx0=0):
-    """
-    Find the index of the first nonzero positive or negative jump in an array.
-
-    Parameters
-    ----------
-    stim: np.ndarray
-        Array to be searched
-
-    idx0: int
-        Start searching with this index (default: 0).
-
-    Returns
-    -------
-    int
-    """
-
-    di = np.diff(stim)
-    idxs = np.flatnonzero(di)
-    idxs = idxs[idxs >= idx0]
-
-    if len(idxs) == 0:
-        return -1
-
-    return idxs[0]+1
-
-
 def get_recording_end_idx(v):
 
     end_idx = np.nonzero(v)[0][-1]  # last non-zero index along the only dimension=0.
@@ -191,12 +164,11 @@ def get_stim_characteristics(i, t, test_pulse=True):
 
     start_idx_idx = 2 if test_pulse else 0     # skip the first up/down (test pulse) if present
 
-    if len(di_idx[start_idx_idx:]) == 0:
+    if len(di_idx[start_idx_idx:]) == 0:    # if no stimulus is found
         return None, None, 0.0, None, None
 
     start_idx = di_idx[start_idx_idx] + 1   # shift by one to compensate for diff()
     end_idx = di_idx[-1]
-
     start_time = float(t[start_idx])
     duration = float(t[end_idx] - t[start_idx-1])
 

--- a/tests/test_epochs.py
+++ b/tests/test_epochs.py
@@ -1,0 +1,29 @@
+import ipfx.epochs as ep
+
+
+def test_find_stim_window():
+    a = [0,1,1,0]
+    stim_start, stim_dur = ep.find_stim_window(a)
+    assert stim_start == 1
+    assert stim_dur == 2
+
+    a = [0,1,1,0,1,1,0]
+    stim_start, stim_dur = ep.find_stim_window(a, idx0=3)
+    assert stim_start == 4
+    assert stim_dur == 2
+
+    a = [1,1,0,0,0,0,0]
+    stim_start, stim_dur = ep.find_stim_window(a)
+    assert stim_start == 2
+    assert stim_dur == 5
+
+    a = [1,1,0,0,0,0,1]
+    stim_start, stim_dur = ep.find_stim_window(a)
+    assert stim_start == 2
+    assert stim_dur == 4
+
+    a = [1,1,0,0,1,0,1]
+    stim_start, stim_dur = ep.find_stim_window(a)
+    assert stim_start == 2
+    assert stim_dur == 4
+

--- a/tests/test_stim_features.py
+++ b/tests/test_stim_features.py
@@ -2,33 +2,6 @@ import ipfx.stim_features as st
 import numpy as np
 
 
-def test_find_stim_window():
-    a = [0,1,1,0]
-    stim_start, stim_dur = st.find_stim_window(a)
-    assert stim_start == 1
-    assert stim_dur == 2
-
-    a = [0,1,1,0,1,1,0]
-    stim_start, stim_dur = st.find_stim_window(a, idx0=3)
-    assert stim_start == 4
-    assert stim_dur == 2
-
-    a = [1,1,0,0,0,0,0]
-    stim_start, stim_dur = st.find_stim_window(a)
-    assert stim_start == 2
-    assert stim_dur == 5
-
-    a = [1,1,0,0,0,0,1]
-    stim_start, stim_dur = st.find_stim_window(a)
-    assert stim_start == 2
-    assert stim_dur == 4
-
-    a = [1,1,0,0,1,0,1]
-    stim_start, stim_dur = st.find_stim_window(a)
-    assert stim_start == 2
-    assert stim_dur == 4
-
-
 def test_get_stim_characteristics():
 
     i = [0,1,1,0]
@@ -111,6 +84,7 @@ def test_get_stim_characteristics():
     assert np.isclose(amplitude, 0.7)
     assert start_idx == 6
     assert end_idx == 12
+
 
 def test_find_stim_interval():
     a = [0,1,0,1,0,1,0]

--- a/tests/test_stim_features.py
+++ b/tests/test_stim_features.py
@@ -1,90 +1,71 @@
 import ipfx.stim_features as st
 import numpy as np
+import pytest
 
+test_params = [
+    (
+        [0,11,11,11,11,11,0,0,0,0,0],  # i
+        False,                         # test_pulse
+        (1,5,11,1,5)                   # stim_characteristics
+     ),
+    (
+        [0,0,1,1,0,0,0.1,0.2,0.3,0.4,0.5,0.6,0.7,0,0],
+        True,
+        (6,7,0.7,6,12)
+     ),
+    (
+        [0,1,1,0,1,1,0],
+        True,
+        (4,2,1,4,5)
+    ),
+    (
+        [0,-2,-1,0],
+        False,
+        (1,2,-2,1,2)
+    ),
+    (
+        [0,0,-1,-1,0,0,-3,-3,-3,-3,0],
+        True,
+        (6,4,-3,6,9)
+    ),
+    (
+        [0,0,-1,-1,0,0,3,3,3,3,0],
+        True,
+        (6,4,3,6,9)
+    ),
+    (
+        [0,0,1,1,0,0,3,3,3,3,0,0],
+        True,
+        (6,4,3,6,9)
+    ),
+    (
+        [0,1,1,0],
+        False,
+        (1,2,1,1,2)
+    )
+]
 
-def test_get_stim_characteristics():
-
-    i = [0,1,1,0]
+@pytest.mark.parametrize('i, test_pulse, stim_characteristics', test_params)
+def test_get_stimuli_characteristics(i, test_pulse, stim_characteristics):
     t = np.arange(len(i))
-    start_time, duration, amplitude, start_idx, end_idx = st.get_stim_characteristics(i, t, test_pulse=False)
-    assert start_time == 1
-    assert np.isclose(duration, 2)
-    assert np.isclose(amplitude,1)
-    assert start_idx == 1
-    assert end_idx == 2
+    start_time, duration, amplitude, start_idx, end_idx = st.get_stim_characteristics(i,t,test_pulse=test_pulse)
+    assert start_time == stim_characteristics[0]
+    assert np.isclose(duration,stim_characteristics[1])
+    assert np.isclose(amplitude, stim_characteristics[2])
+    assert start_idx == stim_characteristics[3]
+    assert end_idx == stim_characteristics[4]
 
-    i = [0,0,1,1,0,0,3,3,3,3,0,0]
-    t = np.arange(len(i))
-    start_time, duration, amplitude, start_idx, end_idx = st.get_stim_characteristics(i, t)
-    assert start_time == 6
-    assert np.isclose(duration,4)
-    assert np.isclose(amplitude, 3)
-    assert start_idx == 6
-    assert end_idx == 9
 
-    i = [0,0,-1,-1,0,0,3,3,3,3,0]
-    t = np.arange(len(i))
-    start_time, duration, amplitude, start_idx, end_idx = st.get_stim_characteristics(i, t)
-    assert start_time == 6
-    assert np.isclose(duration,4)
-    assert np.isclose(amplitude, 3)
-    assert start_idx == 6
-    assert end_idx == 9
-
-    i = [0,0,-1,-1,0,0,-3,-3,-3,-3,0]
-    t = np.arange(len(i))
-    start_time, duration, amplitude, start_idx, end_idx = st.get_stim_characteristics(i, t)
-    assert start_time == 6
-    assert np.isclose(duration,4)
-    assert np.isclose(amplitude, -3)
-    assert start_idx == 6
-    assert end_idx == 9
-
-    i = [0,-2,-1,0]
-    t = np.arange(len(i))
-    start_time, duration, amplitude, start_idx, end_idx = st.get_stim_characteristics(i, t, test_pulse=False)
-    assert start_time == 1
-    assert np.isclose(duration,2)
-    assert np.isclose(amplitude, -2)
-    assert start_idx == 1
-    assert end_idx == 2
-
-    i = [0,1,1,0,1,1,0]
-    t = np.arange(len(i))
-    start_time, duration, amplitude, start_idx, end_idx = st.get_stim_characteristics(i, t)
-    assert start_time == 4
-    assert np.isclose(duration,2)
-    assert np.isclose(amplitude, 1)
-    assert start_idx == 4
-    assert end_idx == 5
+def test_none_get_stimuli_characteristics():
 
     i = [0,1,1,0,0,0,0,0]
     t = np.arange(len(i))
-    start_time, duration, amplitude, start_idx, end_idx = st.get_stim_characteristics(i, t)
-    assert start_time == None
-    assert duration ==None
+    start_time, duration, amplitude, start_idx, end_idx = st.get_stim_characteristics(i,t)
+    assert start_time is None
+    assert duration is None
     assert np.isclose(amplitude, 0)
-    assert start_idx == None
-    assert end_idx == None
-
-    i = [0,11,11,11,11,11,0,0,0,0,0]
-    t = np.arange(len(i))
-    start_time, duration, amplitude, start_idx, end_idx = st.get_stim_characteristics(i, t,test_pulse=False)
-    assert start_time == 1
-    assert np.isclose(duration,5)
-    assert np.isclose(amplitude, 11)
-    assert start_idx == 1
-    assert end_idx == 5
-
-    i = [0,0,1,1,0,0,0.1,0.2,0.3,0.4,0.5,0.6,0.7,0,0]
-    t = np.arange(len(i))
-    start_time, duration, amplitude, start_idx, end_idx = st.get_stim_characteristics(i, t)
-    assert start_time == 6
-    assert np.isclose(duration,7)
-    assert np.isclose(amplitude, 0.7)
-    assert start_idx == 6
-    assert end_idx == 12
-
+    assert start_idx is None
+    assert end_idx is None
 
 def test_find_stim_interval():
     a = [0,1,0,1,0,1,0]

--- a/tests/test_stim_features.py
+++ b/tests/test_stim_features.py
@@ -2,19 +2,6 @@ import ipfx.stim_features as st
 import numpy as np
 
 
-def test_find_stim_start():
-    a = [0,1,1,0]
-    stim_start = st.find_stim_start(a)
-    assert stim_start == 1
-
-    a = [0,1,1,0,1,1,0]
-    stim_start = st.find_stim_start(a, idx0=3)
-    assert stim_start == 4
-
-    a = [1,1,0,0,0,0,0]
-    stim_start = st.find_stim_start(a)
-    assert stim_start == 2
-
 def test_find_stim_window():
     a = [0,1,1,0]
     stim_start, stim_dur = st.find_stim_window(a)


### PR DESCRIPTION
Eliminate redundant find_stim_start function and use consistently a single function for finding stim indexes.
Split epochs detection into a separate module