### PR TITLE
Redefine the meaning of experimental epoch

### DIFF
--- a/ipfx/ephys_data_set.py
+++ b/ipfx/ephys_data_set.py
@@ -165,7 +165,7 @@ class EphysDataSet(object):
         sweep_list = []
         for sweep_number in sweep_numbers:
             sweep = self.sweep(sweep_number)
-            expt_start_idx, _ = ep.get_experiment_epoch(sweep.i,sweep.v,sweep.sampling_rate)
+            expt_start_idx, _ = ep.get_experiment_epoch(sweep.i,sweep.sampling_rate)
             sweep.shift_time_by(expt_start_idx)
             sweep_list.append(sweep)
 

--- a/ipfx/epochs.py
+++ b/ipfx/epochs.py
@@ -13,18 +13,21 @@ LONG_RESPONSE_DURATION = 5  # this will count long ramps as completed
 
 def get_last_vm_epoch(idx1, hz):
     """
-    Get epoch lasting LAST_STABILITY_EPOCH before the end of recording
+    Get epoch lasting LAST_STABILITY_EPOCH before idx1
 
     Parameters
     ----------
-    idx1
-    hz
+    idx1    : int last index of the epoch
+    hz      : float sampling rate
 
     Returns
     -------
+    (idx0,idx1) : int tuple of epoch indices
 
     """
-    return idx1-int(POSTSTIM_STABILITY_EPOCH * hz), idx1
+    idx0 = idx1-int(POSTSTIM_STABILITY_EPOCH * hz)
+
+    return idx0, idx1
 
 
 def get_first_vm_noise_epoch(idx, hz):
@@ -49,6 +52,18 @@ def get_stability_vm_epoch(stim_start, hz):
 
 
 def get_sweep_epoch(response):
+    """
+    Find sweep epoch defined as interval from the beginning of recordign to last non-zero value
+
+    Parameters
+    ----------
+    response    : float np.array
+
+    Returns
+    -------
+    (start_index,end_index): int tuple with start,end indices of the epoch
+
+    """
 
     sweep_end_idx = np.flatnonzero(response)[-1]  # last non-zero index along the only dimension=0.
 
@@ -76,7 +91,6 @@ def get_stim_epoch_A(i,test_pulse=True):
 
 
 def get_stim_epoch_B(i):
-
     """
     Identify start index, and end index of a general stimulus. Assume there is test pulse.
     """
@@ -108,6 +122,16 @@ def get_experiment_epoch(i,hz):
     Find index range for the experiment epoch.
     The start index of the experiment epoch is defined as stim_start_idx - PRESTIM_DURATION*sampling_rate
     The end index of the experiment epoch is defined as stim_end_idx + POSTSTIM_DURATION*sampling_rate
+
+    Parameters
+    ----------
+    i   :   float np.array of current
+    hz  :   float sampling rate
+
+    Returns
+    -------
+    (expt_start_idx,expt_end_idx): int tuple with start, end indices of the epoch
+
     """
 
     stim_start_idx, stim_end_idx = get_stim_epoch(i)

--- a/ipfx/epochs.py
+++ b/ipfx/epochs.py
@@ -75,26 +75,32 @@ def get_stim_epoch_A(i,test_pulse=True):
     return start_idx, end_idx
 
 
-def get_stim_epoch_B(i,test_pulse=True):
+def get_stim_epoch_B(i):
 
     """
-    Identify start index, and end index of a general stimulus.
+    Identify start index, and end index of a general stimulus. Assume there is test pulse.
     """
 
     di = np.diff(i)
-    diff_idx = np.flatnonzero(di)  # != 0)
+    di_idx = np.flatnonzero(di)  # != 0)
 
-    if len(diff_idx) == 0:
+    if len(di_idx) == 0:
         raise ValueError("Empty stimulus trace")
-    if len(diff_idx) >= 4:
+
+    if len(di_idx) >= 4:
         idx = 2  # skip the first up/down assuming that there is a test pulse
     else:
         idx = 0
 
-    start_idx = diff_idx[idx] + 1  # shift by one to compensate for diff()
-    end_idx = diff_idx[-1]
+    start_idx = di_idx[idx] + 1  # shift by one to compensate for diff()
+    end_idx = di_idx[-1]
 
     return start_idx, end_idx
+
+
+def get_stim_epoch(i,test_pulse=True):
+
+    return get_stim_epoch_B(i)
 
 
 def get_experiment_epoch(i,hz):
@@ -102,11 +108,9 @@ def get_experiment_epoch(i,hz):
     Find index range for the experiment epoch.
     The start index of the experiment epoch is defined as stim_start_idx - PRESTIM_DURATION*sampling_rate
     The end index of the experiment epoch is defined as stim_end_idx + POSTSTIM_DURATION*sampling_rate
-
-
     """
 
-    stim_start_idx, stim_end_idx = get_stim_epoch_B(i)
+    stim_start_idx, stim_end_idx = get_stim_epoch(i)
     expt_start_idx = stim_start_idx - int(PRESTIM_STABILITY_EPOCH * hz)
     expt_end_idx = stim_end_idx + int(POSTSTIM_STABILITY_EPOCH * hz)
 

--- a/ipfx/epochs.py
+++ b/ipfx/epochs.py
@@ -97,7 +97,7 @@ def get_stim_epoch_B(i,test_pulse=True):
     return start_idx, end_idx
 
 
-def get_experiment_epoch(i,v,hz):
+def get_experiment_epoch(i,hz):
     """
     Find index range for the experiment epoch.
     The start index of the experiment epoch is defined as stim_start_idx - PRESTIM_DURATION*sampling_rate

--- a/ipfx/plot_qc_figures.py
+++ b/ipfx/plot_qc_figures.py
@@ -34,7 +34,7 @@ def get_features(sweep_features, sweep_number):
 def load_sweep(data_set, sweep_number):
     sweep = data_set.sweep(sweep_number)
     dt = sweep.t[1] - sweep.t[0]
-    r = ep.get_experiment_epoch(sweep.i, sweep.v, sweep.sampling_rate)
+    r = ep.get_experiment_epoch(sweep.i, sweep.sampling_rate)
 
     return (sweep.v, sweep.i, sweep.t, r, dt)
 
@@ -109,7 +109,7 @@ def plot_single_ap_values(data_set, sweep_numbers, lims_features, sweep_features
 
         v, i, t, r, dt = load_sweep(data_set, sn)
         hz = 1./dt
-        expt_start_idx, _ = ep.get_experiment_epoch(i,v,hz)
+        expt_start_idx, _ = ep.get_experiment_epoch(i,hz)
         t = t - expt_start_idx*dt
         plt.plot(t, v, color='black')
         plt.title(str(sn))

--- a/ipfx/qc_features.py
+++ b/ipfx/qc_features.py
@@ -144,7 +144,7 @@ def cell_qc_features(data_set, manual_values=None):
         blowout_sweep_number = data_set.get_sweep_number_by_stimulus_names(ontology.blowout_names)
         blowout_data = data_set.sweep(blowout_sweep_number)
 
-        expt_start_idx, _ = ep.get_experiment_epoch(blowout_data.i, blowout_data.v, blowout_data.sampling_rate)
+        expt_start_idx, _ = ep.get_experiment_epoch(blowout_data.i, blowout_data.sampling_rate)
 
         blowout_mv = measure_blowout(blowout_data.v, expt_start_idx)
         output_data['blowout_mv'] = blowout_mv
@@ -315,7 +315,7 @@ def current_clamp_sweep_qc_features(sweep_data,sweep_info,ontology):
     t = sweep_data.t
     hz = sweep_data.sampling_rate
 
-    expt_start_idx, _ = ep.get_experiment_epoch(current, voltage, hz)
+    expt_start_idx, _ = ep.get_experiment_epoch(current, hz)
     _, sweep_end_idx = ep.get_sweep_epoch(voltage)
 
     # measure Vm and noise before stimulus
@@ -377,7 +377,7 @@ def completed_experiment(i,v,hz):
     LONG_RESPONSE_DURATION = 5  # this will count long ramps as completed
 
     _, sweep_end_ix = ep.get_sweep_epoch(v)
-    _, expt_end_ix = ep.get_experiment_epoch(i, v, hz)
+    _, expt_end_ix = ep.get_experiment_epoch(i, hz)
 
     if sweep_end_ix >= expt_end_ix:
         return True

--- a/tests/test_epochs.py
+++ b/tests/test_epochs.py
@@ -1,5 +1,5 @@
 import ipfx.epochs as ep
-
+import pytest
 
 def test_find_stim_window():
     a = [0,1,1,0]
@@ -27,3 +27,80 @@ def test_find_stim_window():
     assert stim_start == 2
     assert stim_dur == 4
 
+
+@pytest.mark.parametrize('i,'
+                         'sampling_rate,'
+                         'expt_epoch',
+                        [
+                            #   test pulse with square stim
+                            (
+                                [0, 0, 1, 1, 0, 0, 0, 0, 2, 2, 2, 2, 2, 0],
+                                4,
+                                (6, 14)
+                            ),
+
+                            #   test pulse with ramp stim
+                            (
+                                [0, 0, 1, 1, 0, 0, 0, 1, 2, 3, 4, 5, 6, 7, 8, 0, 0, 0, 0],
+                                4,
+                                (5, 16)
+                            ),
+
+                            #   test pulse with triple square
+                            (
+                                [0, 0, 1, 1, 0, 0, 0, 2, 2, 0, 3, 3, 0, 4, 4, 0],
+                                4,
+                                (5, 16)
+                            ),
+
+                            #   negative test pulse with short square stim
+                            (
+                                [0, -1, -1, 0, 0, 0, 1, 1, 0, 0, 0],
+                                4,
+                                (4, 9)
+                            ),
+
+                        ]
+                        )
+def test_get_experiment_epoch(i, sampling_rate, expt_epoch):
+    assert expt_epoch == ep.get_experiment_epoch(i, sampling_rate)
+
+
+@pytest.mark.parametrize('i,'
+                         'stim_epoch',
+                        [
+                            #   test pulse with square stim
+                            (
+                                [0, 0, 1, 1, 0, 0, 2, 2, 2, 2, 2, 0],
+                                (6, 10)
+                            ),
+
+                            #   test pulse with ramp stim
+                            (
+                                [0, 0, 1, 1, 0, 0, 0, 1, 2, 3, 4, 5, 6, 7, 8, 0, 0, 0, 0],
+                                (7, 14)
+                            ),
+
+                            #   test pulse with triple square
+                            (
+                                [0, 0, 1, 1, 0, 0, 0, 2, 2, 0, 3, 3, 0, 4, 4, 0],
+                                (7, 14)
+                            ),
+
+                            #   negative test pulse with short square stim
+                            (
+                                [0, -1, -1, 0, 0, 0, 1, 1, 0, 0, 0],
+                                (6, 7)
+                            ),
+                        ]
+                        )
+def test_get_stim_epoch(i, stim_epoch):
+    assert stim_epoch == ep.get_stim_epoch(i)
+
+
+def test_get_stim_epoch_error():
+
+    i = [0,0,0,0,0,0,0]
+
+    with pytest.raises(ValueError):
+        ep.get_stim_epoch(i)


### PR DESCRIPTION
Now experimental epoch is defined as: 
start index: 0.5 second before stimulus start index
end index:  0.5 second after stimulus end index

Thus, experimental epoch is an expected interval of the response.

The new definition simplifies checking for the sweep truncation: 
if the last index of the response is less than the end of the experimental epoch, then experiment is not fully recorded (i.e, truncated).
