### PR TITLE
Enabling selection of epochs on the existing sweep

### DIFF
--- a/ipfx/aibs_data_set.py
+++ b/ipfx/aibs_data_set.py
@@ -8,10 +8,12 @@ import ipfx.nwb_reader as nwb_reader
 
 
 class AibsDataSet(EphysDataSet):
-    def __init__(self, sweep_info=None, nwb_file=None, h5_file=None, ontology=None, api_sweeps=True):
+    def __init__(self, sweep_info=None, nwb_file=None, h5_file=None,
+                 ontology=None, api_sweeps=True, validate_stim=True):
         super(AibsDataSet, self).__init__(ontology)
 
         self.nwb_data = nwb_reader.create_nwb_reader(nwb_file)
+        self.validate_stim = validate_stim
 
         if sweep_info is not None:
             sweep_info = self.modify_api_sweep_info(
@@ -90,7 +92,7 @@ class AibsDataSet(EphysDataSet):
             sweep_record["stimulus_code_ext"] = stim_code_ext
             sweep_record["stimulus_code"] = stim_code
 
-            if self.ontology:
+            if self.validate_stim:
                 sweep_record["stimulus_name"] = self.get_stimulus_name(stim_code)
 
             sweep_props.append(sweep_record)

--- a/ipfx/aibs_data_set.py
+++ b/ipfx/aibs_data_set.py
@@ -91,9 +91,7 @@ class AibsDataSet(EphysDataSet):
 
             sweep_record["stimulus_code_ext"] = stim_code_ext
             sweep_record["stimulus_code"] = stim_code
-
-            if self.validate_stim:
-                sweep_record["stimulus_name"] = self.get_stimulus_name(stim_code)
+            sweep_record["stimulus_name"] = self.get_stimulus_name(stim_code)
 
             sweep_props.append(sweep_record)
 

--- a/ipfx/data_set_features.py
+++ b/ipfx/data_set_features.py
@@ -217,13 +217,6 @@ def extract_cell_features(data_set,
     return cell_features
 
 
-def stim_align_sweep_set(sweep_set):
-
-    for sweep in sweep_set.sweeps:
-        expt_start_idx, _ = ep.get_experiment_epoch(sweep.i,sweep.sampling_rate)
-        sweep.set_time_zero_to_index(expt_start_idx)
-
-
 def select_subthreshold_min_amplitude(stim_amps, decimals=0):
     """Find the min delta between amplitudes of coarse long square sweeps.  Includes failed sweeps.
 

--- a/ipfx/data_set_features.py
+++ b/ipfx/data_set_features.py
@@ -127,8 +127,8 @@ def extract_sweep_features(data_set, sweep_table):
         logging.debug("%s:%s" % (stimulus_name, ','.join(map(str, sweep_numbers))))
 
         sweep_set = data_set.sweep_set(sweep_numbers)
-        sweep_set.select_epoch("response")
-        stim_align_sweep_set(sweep_set)
+        sweep_set.select_epoch("recording")
+        sweep_set.align_to_start_of_epoch("experiment")
 
         dp = detection_parameters(stimulus_name).copy()
         for k in [ "start", "end" ]:
@@ -158,11 +158,10 @@ def extract_cell_features(data_set,
         raise er.FeatureError("No long_square sweeps available for feature extraction")
 
     lsq_sweeps = data_set.sweep_set(long_square_sweep_numbers)
-    lsq_sweeps.select_epoch("response")
-    stim_align_sweep_set(lsq_sweeps)
+    lsq_sweeps.select_epoch("recording")
+    lsq_sweeps.align_to_start_of_epoch("experiment")
 
     lsq_start, lsq_dur, _, _, _ = stf.get_stim_characteristics(lsq_sweeps.sweeps[0].i, lsq_sweeps.sweeps[0].t)
-
 
     logging.info("Analyzing Long Square")
     logging.info("Long square stim start: %f, duration: %f", lsq_start, lsq_dur)
@@ -184,8 +183,8 @@ def extract_cell_features(data_set,
         raise er.FeatureError("No short square sweeps available for feature extraction")
 
     ssq_sweeps = data_set.sweep_set(short_square_sweep_numbers)
-    ssq_sweeps.select_epoch("response")
-    stim_align_sweep_set(ssq_sweeps)
+    ssq_sweeps.select_epoch("recording")
+    ssq_sweeps.align_to_start_of_epoch("experiment")
 
     ssq_start, ssq_dur, _, _, _ = stf.get_stim_characteristics(ssq_sweeps.sweeps[0].i, ssq_sweeps.sweeps[0].t)
     logging.info("Short square stim start: %f, duration: %f", ssq_start, ssq_dur)
@@ -202,8 +201,8 @@ def extract_cell_features(data_set,
         raise er.FeatureError("No ramp sweeps available for feature extraction")
 
     ramp_sweeps = data_set.sweep_set(ramp_sweep_numbers)
-    ramp_sweeps.select_epoch("response")
-    stim_align_sweep_set(ramp_sweeps)
+    ramp_sweeps.select_epoch("recording")
+    ramp_sweeps.align_to_start_of_epoch("experiment")
 
     ramp_start, ramp_dur, _, _, _ = stf.get_stim_characteristics(ramp_sweeps.sweeps[0].i, ramp_sweeps.sweeps[0].t)
     logging.info("Ramp stim %f, %f", ramp_start, ramp_dur)
@@ -222,7 +221,7 @@ def stim_align_sweep_set(sweep_set):
 
     for sweep in sweep_set.sweeps:
         expt_start_idx, _ = ep.get_experiment_epoch(sweep.i,sweep.sampling_rate)
-        sweep.set_time_zero_to(expt_start_idx)
+        sweep.set_time_zero_to_index(expt_start_idx)
 
 
 def select_subthreshold_min_amplitude(stim_amps, decimals=0):

--- a/ipfx/data_set_features.py
+++ b/ipfx/data_set_features.py
@@ -43,6 +43,8 @@ from . import stimulus_protocol_analysis as spa
 from . import stim_features as stf
 from . import feature_record as fr
 import error as er
+import ipfx.epochs as ep
+
 
 DEFAULT_DETECTION_PARAMETERS = { 'dv_cutoff': 20.0, 'thresh_frac': 0.05 }
 
@@ -124,7 +126,9 @@ def extract_sweep_features(data_set, sweep_table):
         sweep_numbers = sorted(sweep_numbers)
         logging.debug("%s:%s" % (stimulus_name, ','.join(map(str, sweep_numbers))))
 
-        sweep_set = data_set.stim_aligned_sweep_set(sweep_numbers)
+        sweep_set = data_set.sweep_set(sweep_numbers)
+        sweep_set.select_epoch("response")
+        stim_align_sweep_set(sweep_set)
 
         dp = detection_parameters(stimulus_name).copy()
         for k in [ "start", "end" ]:
@@ -153,7 +157,10 @@ def extract_cell_features(data_set,
     if len(long_square_sweep_numbers) == 0:
         raise er.FeatureError("No long_square sweeps available for feature extraction")
 
-    lsq_sweeps = data_set.stim_aligned_sweep_set(long_square_sweep_numbers)
+    lsq_sweeps = data_set.sweep_set(long_square_sweep_numbers)
+    lsq_sweeps.select_epoch("response")
+    stim_align_sweep_set(lsq_sweeps)
+
     lsq_start, lsq_dur, _, _, _ = stf.get_stim_characteristics(lsq_sweeps.sweeps[0].i, lsq_sweeps.sweeps[0].t)
 
 
@@ -176,7 +183,9 @@ def extract_cell_features(data_set,
     if len(short_square_sweep_numbers) == 0:
         raise er.FeatureError("No short square sweeps available for feature extraction")
 
-    ssq_sweeps = data_set.stim_aligned_sweep_set(short_square_sweep_numbers)
+    ssq_sweeps = data_set.sweep_set(short_square_sweep_numbers)
+    ssq_sweeps.select_epoch("response")
+    stim_align_sweep_set(ssq_sweeps)
 
     ssq_start, ssq_dur, _, _, _ = stf.get_stim_characteristics(ssq_sweeps.sweeps[0].i, ssq_sweeps.sweeps[0].t)
     logging.info("Short square stim start: %f, duration: %f", ssq_start, ssq_dur)
@@ -192,7 +201,9 @@ def extract_cell_features(data_set,
     if len(ramp_sweep_numbers) == 0:
         raise er.FeatureError("No ramp sweeps available for feature extraction")
 
-    ramp_sweeps = data_set.stim_aligned_sweep_set(ramp_sweep_numbers)
+    ramp_sweeps = data_set.sweep_set(ramp_sweep_numbers)
+    ramp_sweeps.select_epoch("response")
+    stim_align_sweep_set(ramp_sweeps)
 
     ramp_start, ramp_dur, _, _, _ = stf.get_stim_characteristics(ramp_sweeps.sweeps[0].i, ramp_sweeps.sweeps[0].t)
     logging.info("Ramp stim %f, %f", ramp_start, ramp_dur)

--- a/ipfx/data_set_features.py
+++ b/ipfx/data_set_features.py
@@ -207,6 +207,13 @@ def extract_cell_features(data_set,
     return cell_features
 
 
+def stim_align_sweep_set(sweep_set):
+
+    for sweep in sweep_set.sweeps:
+        expt_start_idx, _ = ep.get_experiment_epoch(sweep.i,sweep.sampling_rate)
+        sweep.set_time_zero_to(expt_start_idx)
+
+
 def select_subthreshold_min_amplitude(stim_amps, decimals=0):
     """Find the min delta between amplitudes of coarse long square sweeps.  Includes failed sweeps.
 

--- a/ipfx/ephys_data_set.py
+++ b/ipfx/ephys_data_set.py
@@ -115,7 +115,6 @@ class EphysDataSet(object):
         t = np.arange(0, len(sweep_data['stimulus'])) * dt
 
         epochs = sweep_data.get('epochs')
-
         clamp_mode = self.get_clamp_mode(sweep_meta_data['stimulus_units'])
 
         if clamp_mode == "VoltageClamp":

--- a/ipfx/ephys_data_set.py
+++ b/ipfx/ephys_data_set.py
@@ -28,7 +28,7 @@ class EphysDataSet(object):
 
     def __init__(self, ontology=None):
         self.sweep_table = None
-        self.ontology = ontology if ontology else StimulusOntology()
+        self.ontology = ontology
 
     def filtered_sweep_table(self,
                              current_clamp_only=False,

--- a/ipfx/ephys_data_set.py
+++ b/ipfx/ephys_data_set.py
@@ -24,6 +24,8 @@ class EphysDataSet(object):
     SHORT_SQUARE = 'short_square'
     RAMP = 'ramp'
 
+    current_clamp_units = ('Amps', 'pA')
+
     def __init__(self, ontology=None):
         self.sweep_table = None
         self.ontology = ontology if ontology else StimulusOntology()
@@ -40,8 +42,7 @@ class EphysDataSet(object):
         st = self.sweep_table
 
         if current_clamp_only:
-            st = st[st[self.STIMULUS_UNITS].isin(
-                self.ontology.current_clamp_units)]
+            st = st[st[self.STIMULUS_UNITS].isin(self.current_clamp_units)]
 
         if passing_only:
             st = st[st[self.PASSED]]
@@ -147,7 +148,7 @@ class EphysDataSet(object):
 
     def get_clamp_mode(self, stimulus_unit):
 
-        clamp_mode = "CurrentClamp" if stimulus_unit in self.ontology.current_clamp_units else "VoltageClamp"
+        clamp_mode = "CurrentClamp" if stimulus_unit in self.current_clamp_units else "VoltageClamp"
 
         return clamp_mode
 

--- a/ipfx/ephys_data_set.py
+++ b/ipfx/ephys_data_set.py
@@ -161,18 +161,6 @@ class EphysDataSet(object):
     def aligned_sweeps(self, sweep_numbers, stim_onset_delta):
         raise NotImplementedError
 
-    def stim_aligned_sweep_set(self,sweep_numbers):
-
-        sweep_list = []
-        for sweep_number in sweep_numbers:
-            sweep = self.sweep(sweep_number)
-            expt_start_idx, _ = ep.get_experiment_epoch(sweep.i,sweep.sampling_rate)
-            sweep.shift_time_by(expt_start_idx)
-            sweep_list.append(sweep)
-
-        return SweepSet(sweep_list)
-
-
     def extract_sweep_meta_data(self):
         """
         Returns

--- a/ipfx/ephys_data_set.py
+++ b/ipfx/ephys_data_set.py
@@ -1,3 +1,4 @@
+import warnings
 import logging
 import re
 
@@ -194,6 +195,13 @@ class EphysDataSet(object):
         if not self.ontology:
             raise ValueError("Missing stimulus ontology")
 
-        stim = self.ontology.find_one(stim_code, tag_type="code")
-        return stim.tags(tag_type="name")[0][-1]
+        try:
+            stim = self.ontology.find_one(stim_code, tag_type="code")
+            return stim.tags(tag_type="name")[0][-1]
 
+        except KeyError:
+            if self.validate_stim:
+                raise
+            else:
+                warnings.warn("Stimulus code {} is not in the ontology".format(stim_code))
+                return

--- a/ipfx/ephys_data_set.py
+++ b/ipfx/ephys_data_set.py
@@ -3,7 +3,6 @@ import re
 
 import numpy as np
 from ipfx.stimulus import StimulusOntology
-import ipfx.epochs as ep
 from ipfx.sweep import Sweep,SweepSet
 
 
@@ -28,7 +27,7 @@ class EphysDataSet(object):
 
     def __init__(self, ontology=None):
         self.sweep_table = None
-        self.ontology = ontology
+        self.ontology = ontology if ontology else StimulusOntology()
 
     def filtered_sweep_table(self,
                              current_clamp_only=False,
@@ -82,7 +81,6 @@ class EphysDataSet(object):
 
     def get_sweep_meta_data(self, sweep_number):
         """
-
         Parameters
         ----------
         sweep_number: int sweep number
@@ -99,15 +97,15 @@ class EphysDataSet(object):
     def sweep(self, sweep_number):
 
         """
-        Create an instance of the Sweep object from a data set sweep
+        Create an instance of the Sweep class with the data loaded from the from a file
 
         Parameters
         ----------
-        sweep_number
+        sweep_number: int
 
         Returns
         -------
-        Sweep object
+        sweep: Sweep object
         """
 
         sweep_data = self.get_sweep_data(sweep_number)
@@ -115,12 +113,8 @@ class EphysDataSet(object):
         sampling_rate = sweep_data['sampling_rate']
         dt = 1. / sampling_rate
         t = np.arange(0, len(sweep_data['stimulus'])) * dt
-        assert len(sweep_data['stimulus']) == len(sweep_data['response'])
 
-        try:
-            epochs = sweep_data['epochs']
-        except KeyError:
-            epochs = {}
+        epochs = sweep_data.get('epochs')
 
         clamp_mode = self.get_clamp_mode(sweep_meta_data['stimulus_units'])
 

--- a/ipfx/plot_qc_figures.py
+++ b/ipfx/plot_qc_figures.py
@@ -111,6 +111,7 @@ def plot_single_ap_values(data_set, sweep_numbers, lims_features, sweep_features
         hz = 1./dt
         expt_start_idx, _ = ep.get_experiment_epoch(i,hz)
         t = t - expt_start_idx*dt
+        stim_start_shifted = stim_start - expt_start_idx*dt
         plt.plot(t, v, color='black')
         plt.title(str(sn))
 
@@ -145,7 +146,7 @@ def plot_single_ap_values(data_set, sweep_numbers, lims_features, sweep_features
             if nspikes:
                 plt.xlim(spikes[0]["threshold_t"] - 0.002, spikes[0]["fast_trough_t"] + 0.01)
         elif type_name == "short_square":
-            plt.xlim(stim_start - 0.002, stim_start + stim_dur + 0.01)
+            plt.xlim(stim_start_shifted - 0.002, stim_start_shifted + stim_dur + 0.01)
         elif type_name == "long_square":
             plt.xlim(times[0]- 0.002, times[-2] + 0.002)
 
@@ -174,8 +175,7 @@ def plot_sweep_figures(data_set, image_dir, sizes):
             if r_init[0] <= 0:
                 r_init = (5000,r_init[1])
 
-            tp_steps = r_init[0]
-            tp_len = tp_steps*dt_init
+            tp_steps = int(0.1/dt_init)
             tp_fig = plt.figure()
             axTP = plt.gca()
             axTP.set_title(str(sweep_number))
@@ -210,8 +210,7 @@ def plot_sweep_figures(data_set, image_dir, sizes):
             if r[0] <= 0:       # This happens when stimulus starts less than 0.5 s after test pulse
                 r = (5000,r[1]) # Manually set start of experiment to a default positive value
 
-            tp_steps = r[0]
-            tp_len = tp_steps*dt
+            tp_steps = int(0.1/dt_init)
 
             tp_fig = plt.figure()
             axTP = plt.gca()

--- a/ipfx/qc_protocol.py
+++ b/ipfx/qc_protocol.py
@@ -140,8 +140,8 @@ def qc_current_clamp_sweep(ontology, sweep, qc_criteria=None):
     # keep track of failures
     fail_tags = []
 
-    if sweep["stimulus_units"] not in ontology.current_clamp_units:
-        return {}
+#    if sweep["stimulus_units"] not in ontology.current_clamp_units:
+#        return {}
 
     if sweep["pre_noise_rms_mv"] > qc_criteria["pre_noise_rms_mv_max"]:
         fail_tags.append("pre-noise: %.3f exceeded qc threshold: %.3f" %(sweep["pre_noise_rms_mv"],qc_criteria["pre_noise_rms_mv_max"]))

--- a/ipfx/stimulus.py
+++ b/ipfx/stimulus.py
@@ -66,8 +66,6 @@ class StimulusOntology(object):
         self.breakin_names = ( 'EXTPBREAKN', )
         self.extp_names = ( 'EXTP', )
 
-        self.current_clamp_units = ( 'Amps', 'pA')
-
     def find(self, tag, tag_type=None):
         matching_stims = [ s for s in self.stimuli if s.has_tag(tag, tag_type=tag_type) ]
 

--- a/ipfx/sweep.py
+++ b/ipfx/sweep.py
@@ -29,29 +29,28 @@ class Sweep(object):
     @property
     def t(self):
         start_idx, end_idx = self.epochs[self.selected_epoch_name]
-        return self._t[start_idx:end_idx]
+        return self._t[start_idx:end_idx+1]
 
     @property
     def v(self):
         start_idx, end_idx = self.epochs[self.selected_epoch_name]
-        return self._v[start_idx:end_idx]
+        return self._v[start_idx:end_idx+1]
 
     @property
     def i(self):
         start_idx, end_idx = self.epochs[self.selected_epoch_name]
-        return self._i[start_idx:end_idx]
+        return self._i[start_idx:end_idx+1]
 
     def select_epoch(self, epoch_name):
         self.selected_epoch_name = epoch_name
 
-    def set_time_zero_to(self, time_steps):
-
+    def set_time_zero_to(self, time_step):
         dt = 1. / self.sampling_rate
-        self._t = self._t - time_steps*dt
+        self._t = self._t - time_step*dt
 
     def detect_missing_epochs(self):
         """
-        If epochs are not provided in the constructor then detect them
+        Detect epochs if they are not provided in the constructor
 
         """
 
@@ -71,15 +70,21 @@ class Sweep(object):
 
     def detect_sweep_epoch(self):
         """
-        index range of the entire sweep
+        Detect sweep epoch defined as interval including entire sweep
 
+        Returns
+        -------
+        start,end: int indices of the epoch
         """
         return 0, len(self.response)
 
     def detect_response_epoch(self):
         """
-        index range from start to last nonzero response
+        Detect response epoch defined as interval from start to the last non-zero value of the response
 
+        Returns
+        -------
+        start,end: int indices of the epoch
         """
         return 0, np.flatnonzero(self.response)[-1]
 

--- a/ipfx/sweep.py
+++ b/ipfx/sweep.py
@@ -9,7 +9,12 @@ class Sweep(object):
         self.sampling_rate = sampling_rate
         self.sweep_number = sweep_number
         self.clamp_mode = clamp_mode
-        self.epochs = epochs
+
+        if epochs:
+            self.epochs = epochs
+        else:
+            self.epochs = {}
+
         self.selected_epoch_name = "sweep"
 
         if self.clamp_mode == "CurrentClamp":

--- a/tests/test_sweep.py
+++ b/tests/test_sweep.py
@@ -19,7 +19,7 @@ def test_select_epoch(sweep):
     i_sweep = sweep.i
     v_sweep = sweep.v
 
-    sweep.select_epoch("response")
+    sweep.select_epoch("recording")
     assert sweep.i == [0,0,1,1,0,0,0,2,2,2,2]
     assert sweep.v == [0,0,1,2,1,0,0,1,2,3,1]
 
@@ -28,10 +28,10 @@ def test_select_epoch(sweep):
     assert sweep.v == v_sweep
 
 
-def test_set_time_zero_to(sweep):
+def test_set_time_zero_to_index(sweep):
 
     t0_idx = 7
-    sweep.set_time_zero_to(t0_idx)
+    sweep.set_time_zero_to_index(t0_idx)
 
     assert np.isclose(sweep.t[t0_idx], 0.0)
 

--- a/tests/test_sweep.py
+++ b/tests/test_sweep.py
@@ -1,0 +1,38 @@
+from ipfx.sweep import Sweep
+import pytest
+import numpy as np
+
+@pytest.fixture()
+def sweep():
+
+    i = [0,0,1,1,0,0,0,2,2,2,2,2,0,0,0,0]
+    v = [0,0,1,2,1,0,0,1,2,3,1,0,0,0,0,0]
+    sampling_rate = 2
+    dt = 1./sampling_rate
+    t = np.arange(0,len(v))*dt
+
+    return Sweep(t, v, i, sampling_rate=sampling_rate, clamp_mode="CurrentClamp")
+
+
+def test_select_epoch(sweep):
+
+    i_sweep = sweep.i
+    v_sweep = sweep.v
+
+    sweep.select_epoch("response")
+    assert sweep.i == [0,0,1,1,0,0,0,2,2,2,2]
+    assert sweep.v == [0,0,1,2,1,0,0,1,2,3,1]
+
+    sweep.select_epoch("sweep")
+    assert sweep.i == i_sweep
+    assert sweep.v == v_sweep
+
+
+def test_set_time_zero_to(sweep):
+
+    t0_idx = 7
+    sweep.set_time_zero_to(t0_idx)
+
+    assert np.isclose(sweep.t[t0_idx], 0.0)
+
+


### PR DESCRIPTION
Previously, selecting epochs of a sweep required re-loading data from the nwb file.
Now, sweep is created with all data and epochs are detected. We can now request different epochs on the existing sweep without needing to reload data. 
Epochs are now actions of the Sweep class rather than entire data set.
This PR is a bit of WIP...