### PR TITLE
Enable checking for clamp mode when returning sweep number

### DIFF
--- a/ipfx/data_set_features.py
+++ b/ipfx/data_set_features.py
@@ -272,26 +272,28 @@ def extract_data_set_features(data_set, subthresh_min_amp=None):
     """
     ontology = data_set.ontology
     # for logging purposes
-    iclamp_sweeps = data_set.filtered_sweep_table(current_clamp_only=True)
-    passed_iclamp_sweeps = data_set.filtered_sweep_table(current_clamp_only=True, passing_only=True)
+    iclamp_sweeps = data_set.filtered_sweep_table(clamp_mode=data_set.CURRENT_CLAMP)
+    passed_iclamp_sweeps = data_set.filtered_sweep_table(clamp_mode=data_set.CURRENT_CLAMP,
+                                                         passing_only=True)
 
     if len(passed_iclamp_sweeps) == 0:
         raise er.FeatureError("There are no QC-passed sweeps available to analyze")
 
     # extract cell-level features
 
-    clsq_sweeps = data_set.filtered_sweep_table(current_clamp_only=True, stimuli=ontology.coarse_long_square_names)
+    clsq_sweeps = data_set.filtered_sweep_table(clamp_mode=data_set.CURRENT_CLAMP,
+                                                stimuli=ontology.coarse_long_square_names)
     clsq_sweep_numbers = clsq_sweeps['sweep_number'].sort_values().values
 
-    lsq_sweep_numbers = data_set.filtered_sweep_table(current_clamp_only=True,
+    lsq_sweep_numbers = data_set.filtered_sweep_table(clamp_mode=data_set.CURRENT_CLAMP,
                                                       passing_only=True,
                                                       stimuli=ontology.long_square_names).sweep_number.sort_values().values
 
-    ssq_sweep_numbers = data_set.filtered_sweep_table(current_clamp_only=True,
+    ssq_sweep_numbers = data_set.filtered_sweep_table(clamp_mode=data_set.CURRENT_CLAMP,
                                                       passing_only=True,
                                                       stimuli=ontology.short_square_names).sweep_number.sort_values().values
 
-    ramp_sweep_numbers = data_set.filtered_sweep_table(current_clamp_only=True,
+    ramp_sweep_numbers = data_set.filtered_sweep_table(clamp_mode=data_set.CURRENT_CLAMP,
                                                        passing_only=True,
                                                        stimuli=ontology.ramp_names).sweep_number.sort_values().values
 

--- a/ipfx/ephys_data_set.py
+++ b/ipfx/ephys_data_set.py
@@ -81,17 +81,19 @@ class EphysDataSet(object):
             mask = st[self.SWEEP_NUMBER] == sweep_number
             st = st[mask]
 
-
         return st
 
-    def get_sweep_number_by_stimulus_names(self, stimulus_names):
+    def get_sweep_number(self, stimuli, clamp_mode=None):
 
-        sweeps = self.filtered_sweep_table(
-            stimuli=stimulus_names).sort_values(by=self.SWEEP_NUMBER)
+        sweeps = self.filtered_sweep_table(stimuli=stimuli).sort_values(by=self.SWEEP_NUMBER)
+
+        if clamp_mode:
+            mask = sweeps[self.CLAMP_MODE] == clamp_mode
+            sweeps = sweeps[mask]
 
         if len(sweeps) > 1:
             logging.warning(
-                "Found multiple sweeps for stimulus %s: using largest sweep number" % str(stimulus_names))
+                "Found multiple sweeps for stimulus %s: using largest sweep number" % str(stimuli))
 
         if len(sweeps) == 0:
             raise IndexError
@@ -135,7 +137,6 @@ class EphysDataSet(object):
 
         epochs = sweep_data.get('epochs')
         clamp_mode = self.get_clamp_mode(sweep_meta_data['stimulus_units'])
-
         if clamp_mode == "VoltageClamp":
             v = sweep_data['stimulus']
             i = sweep_data['response']

--- a/ipfx/plot_qc_figures.py
+++ b/ipfx/plot_qc_figures.py
@@ -158,10 +158,9 @@ def plot_single_ap_values(data_set, sweep_numbers, lims_features, sweep_features
 
 def plot_sweep_figures(data_set, image_dir, sizes):
 
-    iclamp_sweep_numbers = data_set.filtered_sweep_table(current_clamp_only=True, passing_only=False)['sweep_number'].values
+    iclamp_sweep_numbers = data_set.filtered_sweep_table(clamp_mode=data_set.CURRENT_CLAMP)['sweep_number'].values
     iclamp_sweep_numbers.sort()
     image_file_sets = {}
-
 
     b, a = sg.bessel(4, 0.1, "low")
 
@@ -449,7 +448,7 @@ def plot_instantaneous_threshold_thumbnail(data_set, sweep_numbers, cell_feature
 def plot_ramp_figures(data_set, cell_features, lims_features, sweep_features, image_dir, sizes, cell_image_files):
 
     ramps_sweeps = data_set.filtered_sweep_table(passing_only=True,
-                                                 current_clamp_only=True,
+                                                 current_clamp=data_set.CURRENT_CLAMP,
                                                  stimuli=data_set.ontology.ramp_names)
     ramps_sweeps = np.sort(ramps_sweeps['sweep_number'].values)
 

--- a/ipfx/qc_feature_extractor.py
+++ b/ipfx/qc_feature_extractor.py
@@ -25,7 +25,7 @@ def extract_blowout(data_set, tags):
     ontology = data_set.ontology
 
     try:
-        blowout_sweep_number = data_set.get_sweep_number_by_stimulus_names(ontology.blowout_names)
+        blowout_sweep_number = data_set.get_sweep_number(ontology.blowout_names)
         blowout_data = data_set.sweep(blowout_sweep_number)
         _,test_end_idx = blowout_data.epochs["test"]
         blowout_mv = qcf.measure_blowout(blowout_data.v, test_end_idx)
@@ -55,7 +55,7 @@ def extract_electrode_0(data_set, tags):
     ontology = data_set.ontology
 
     try:
-        bath_sweep_number = data_set.get_sweep_number_by_stimulus_names(ontology.bath_names)
+        bath_sweep_number = data_set.get_sweep_number(ontology.bath_names)
         bath_data = data_set.sweep(bath_sweep_number)
 
         e0 = qcf.measure_electrode_0(bath_data.i, bath_data.sampling_rate)
@@ -85,7 +85,7 @@ def extract_clamp_seal(data_set, tags, manual_values=None):
     ontology = data_set.ontology
 
     try:
-        seal_sweep_number = data_set.get_sweep_number_by_stimulus_names(ontology.seal_names)
+        seal_sweep_number = data_set.get_sweep_number(ontology.seal_names,"VoltageClamp")
         seal_data = data_set.sweep(seal_sweep_number)
 
         seal_gohm = qcf.measure_seal(seal_data.v,
@@ -137,7 +137,7 @@ def extract_input_and_access_resistance(data_set, tags, manual_values=None):
 
 
     try:
-        breakin_sweep_number = data_set.get_sweep_number_by_stimulus_names(ontology.breakin_names)
+        breakin_sweep_number = data_set.get_sweep_number(ontology.breakin_names,"VoltageClamp")
         breakin_data = data_set.sweep(breakin_sweep_number)
     except IndexError as e:
         tags.append("Breakin sweep not found")

--- a/ipfx/qc_feature_extractor.py
+++ b/ipfx/qc_feature_extractor.py
@@ -251,9 +251,8 @@ def sweep_qc_features(data_set):
 
     ontology = data_set.ontology
     sweeps_features = []
-    iclamp_sweeps = data_set.filtered_sweep_table(current_clamp_only=True,
-                                                  exclude_test=True,
-                                                  exclude_search=True,
+    iclamp_sweeps = data_set.filtered_sweep_table(clamp_mode=data_set.CURRENT_CLAMP,
+                                                  stimuli_exclude=["Test", "Search"],
                                                   )
     if len(iclamp_sweeps.index) == 0:
         logging.warning("No current clamp sweeps available to compute QC features")

--- a/ipfx/qc_features.py
+++ b/ipfx/qc_features.py
@@ -63,7 +63,7 @@ def get_r_from_stable_pulse_response(v, i, t):
     dv = np.diff(v)
     up_idx = np.flatnonzero(dv > 0)
     down_idx = np.flatnonzero(dv < 0)
-    assert len(up_idx) == len(down_idx), "Truncated breakin sweep, truncated response to a square pulse"
+    assert len(up_idx) == len(down_idx), "Truncated square pulse"
     dt = t[1] - t[0]
     one_ms = int(0.001 / dt)
 
@@ -94,7 +94,7 @@ def get_r_from_peak_pulse_response(v, i, t):
     dv = np.diff(v)
     up_idx = np.flatnonzero(dv > 0)
     down_idx = np.flatnonzero(dv < 0)
-    assert len(up_idx) == len(down_idx), "Truncated breakin sweep, truncated response to a square pulse"
+    assert len(up_idx) == len(down_idx), "Truncated square pulse"
 
     dt = t[1] - t[0]
     one_ms = int(0.001 / dt)

--- a/tests/test_ephys_data_set.py
+++ b/tests/test_ephys_data_set.py
@@ -46,8 +46,6 @@ def test_emtpy_table_has_header():
 
     assert list(ds.filtered_sweep_table(stimuli=['I_DONT_EXIST'])) == list(ds.sweep_table)
 
-    assert list(ds.filtered_sweep_table(sweep_number=7)) == list(ds.sweep_table)
-
 
 def test_get_sweep_number_invalid_sweep():
 
@@ -68,7 +66,14 @@ def test_get_sweep_number_works_and_returns_only_the_last():
     assert sweeps == 6
 
 
-def test_filtered_sweep_table_works():
+def test_get_sweep_number_wrong_clamp_mode():
+
+    with pytest.raises(IndexError):
+        ds = get_dataset()
+        ds.get_sweep_number(['Long Square'], clamp_mode="VoltageClamp")
+
+
+def test_filtered_sweep_table_stimuli():
 
     ds = get_dataset()
     sweeps = ds.filtered_sweep_table(stimuli=['EXTPBREAKN'])
@@ -76,12 +81,10 @@ def test_filtered_sweep_table_works():
     assert sweeps["sweep_number"].tolist() == [5, 6]
 
 
-def test_filtered_sweep_table_works_with_sweep_number():
-
+def test_filtered_sweep_table_stimuli_exclude():
     ds = get_dataset()
-    sweeps = ds.filtered_sweep_table(sweep_number=0)
-
-    assert sweeps["sweep_number"].tolist() == [0]
+    sweeps = ds.filtered_sweep_table(stimuli_exclude=["Test"])
+    assert sweeps["sweep_number"].values == 0
 
 
 def test_get_sweep_meta_data():

--- a/tests/test_ephys_data_set.py
+++ b/tests/test_ephys_data_set.py
@@ -49,22 +49,22 @@ def test_emtpy_table_has_header():
     assert list(ds.filtered_sweep_table(sweep_number=7)) == list(ds.sweep_table)
 
 
-def test_get_sweep_number_by_stimulus_name_invalid_sweep():
+def test_get_sweep_number_invalid_sweep():
 
     with pytest.raises(IndexError):
         ds = get_dataset()
-        ds.get_sweep_number_by_stimulus_names(['I_DONT_EXIST'])
+        ds.get_sweep_number(['I_DONT_EXIST'])
 
 
-def test_get_sweep_number_by_stimulus_name_works_1():
+def test_get_sweep_number_works_1():
     ds = get_dataset()
-    sweeps = ds.get_sweep_number_by_stimulus_names(['C1LSFINEST'])
+    sweeps = ds.get_sweep_number(['C1LSFINEST'])
     assert sweeps == 0
 
 
-def test_get_sweep_number_by_stimulus_name_works_and_returns_only_the_last():
+def test_get_sweep_number_works_and_returns_only_the_last():
     ds = get_dataset()
-    sweeps = ds.get_sweep_number_by_stimulus_names(['EXTPBREAKN'])
+    sweeps = ds.get_sweep_number(['EXTPBREAKN'])
     assert sweeps == 6
 
 

--- a/tests/test_hbg_dataset.py
+++ b/tests/test_hbg_dataset.py
@@ -45,17 +45,17 @@ def test_main_dat(ontology, NWB_file):
 
     dataset = HBGDataSet(nwb_file=NWB_file, ontology=ontology)
 
-    expected = {'stimulus_units': {0: 'V'},
-                'clamp_mode': {0: 'VoltageClamp'},
-                'sweep_number': {0: 10101},
-                'leak_pa': {0: None},
-                'stimulus_code_ext': {0: None},
-                'stimulus_scale_factor': {0: 5000000.0},
-                'stimulus_code': {0: u'extpinbath'},
-                'stimulus_name': {0: u'extpinbath stimulus'},
-                'bridge_balance_mohm': {0: None}
+    expected = {'stimulus_units': 'V',
+                'clamp_mode': 'VoltageClamp',
+                'sweep_number': 10101,
+                'leak_pa': None,
+                'stimulus_code_ext': None,
+                'stimulus_scale_factor': 5000000.0,
+                'stimulus_code': u'extpinbath',
+                'stimulus_name': u'extpinbath stimulus',
+                'bridge_balance_mohm': None
                 }
-    # only compare one sweep
-    sweep_table = dataset.filtered_sweep_table(sweep_number=10101)
 
-    compare_dicts(expected, sweep_table.to_dict())
+    # only compare one sweep
+    sweep_meta_data = dataset.get_sweep_meta_data(10101)
+    compare_dicts(expected, sweep_meta_data)


### PR DESCRIPTION
Some cells have duplicated test sweeps but marked as VoltageClamp
This feature enable choosing only the desired clamp modes.
Resolves #181 