### PR TITLE
Extract clamp mode from nwb file

### DIFF
--- a/ipfx/aibs_data_set.py
+++ b/ipfx/aibs_data_set.py
@@ -4,6 +4,7 @@ from .ephys_data_set import EphysDataSet
 
 import ipfx.lab_notebook_reader as lab_notebook_reader
 import ipfx.nwb_reader as nwb_reader
+import ipfx.sweep_props as sp
 
 
 class AibsDataSet(EphysDataSet):
@@ -13,9 +14,8 @@ class AibsDataSet(EphysDataSet):
 
         self.nwb_data = nwb_reader.create_nwb_reader(nwb_file)
 
-        if sweep_info is not None:
-            sweep_info = self.modify_api_sweep_info(
-                sweep_info) if api_sweeps else sweep_info
+        if sweep_info:
+            sweep_info = sp.modify_sweep_info_keys(sweep_info) if api_sweeps else sweep_info
         else:
             self.notebook = lab_notebook_reader.create_lab_notebook_reader(nwb_file, h5_file)
             sweep_info = self.extract_sweep_meta_data()

--- a/ipfx/aibs_data_set.py
+++ b/ipfx/aibs_data_set.py
@@ -18,26 +18,25 @@ class AibsDataSet(EphysDataSet):
             sweep_info = sp.modify_sweep_info_keys(sweep_info) if api_sweeps else sweep_info
         else:
             self.notebook = lab_notebook_reader.create_lab_notebook_reader(nwb_file, h5_file)
-            sweep_info = self.extract_sweep_meta_data()
+            sweep_info = self.extract_sweep_stim_info()
 
         self.build_sweep_table(sweep_info)
 
-    def extract_sweep_meta_data(self):
+    def extract_sweep_stim_info(self):
         """
 
         Returns
         -------
-        sweep_props: list of dicts
+        sweep_info: list of dicts
             where each dict includes sweep properties
         """
-        sweep_props = []
+        sweep_info = []
         for index, sweep_map in self.nwb_data.sweep_map_table.iterrows():
             sweep_record = {}
             sweep_num = sweep_map["sweep_number"]
             sweep_record['sweep_number'] = sweep_num
 
             sweep_record['stimulus_units'] = self.get_stimulus_units(sweep_num)
-            sweep_record['clamp_mode'] = self.get_clamp_mode(sweep_num)
 
             # bridge balance
             sweep_record["bridge_balance_mohm"] = self.notebook.get_value(
@@ -58,9 +57,9 @@ class AibsDataSet(EphysDataSet):
             sweep_record["stimulus_code_ext"] = stim_code_ext
             sweep_record["stimulus_name"] = self.get_stimulus_name(stim_code)
 
-            sweep_props.append(sweep_record)
+            sweep_info.append(sweep_record)
 
-        return sweep_props
+        return sweep_info
 
     def get_stimulus_code(self, sweep_num):
 

--- a/ipfx/bin/run_feature_extraction.py
+++ b/ipfx/bin/run_feature_extraction.py
@@ -7,6 +7,7 @@ import ipfx.data_set_features as dsft
 from ipfx.stimulus import StimulusOntology
 from ipfx._schemas import FeatureExtractionParameters
 from ipfx.data_set_utils import create_data_set
+import ipfx.sweep_props as sp
 
 import allensdk.core.json_utilities as ju
 from allensdk.core.nwb_data_set import NwbDataSet
@@ -41,6 +42,10 @@ def run_feature_extraction(input_nwb_file,
                            cell_info):
 
     lu.log_pretty_header("Extract ephys features", level=1)
+
+    sp.drop_failed_sweeps(sweep_info)
+    if len(sweep_info) == 0:
+        raise er.FeatureError("There are no QC-passed sweeps available to analyze")
 
     ont = StimulusOntology(ju.read(stimulus_ontology_file)) if stimulus_ontology_file else StimulusOntology()
 

--- a/ipfx/data_set_features.py
+++ b/ipfx/data_set_features.py
@@ -273,11 +273,6 @@ def extract_data_set_features(data_set, subthresh_min_amp=None):
     ontology = data_set.ontology
     # for logging purposes
     iclamp_sweeps = data_set.filtered_sweep_table(clamp_mode=data_set.CURRENT_CLAMP)
-    passed_iclamp_sweeps = data_set.filtered_sweep_table(clamp_mode=data_set.CURRENT_CLAMP,
-                                                         passing_only=True)
-
-    if len(passed_iclamp_sweeps) == 0:
-        raise er.FeatureError("There are no QC-passed sweeps available to analyze")
 
     # extract cell-level features
 
@@ -286,15 +281,12 @@ def extract_data_set_features(data_set, subthresh_min_amp=None):
     clsq_sweep_numbers = clsq_sweeps['sweep_number'].sort_values().values
 
     lsq_sweep_numbers = data_set.filtered_sweep_table(clamp_mode=data_set.CURRENT_CLAMP,
-                                                      passing_only=True,
                                                       stimuli=ontology.long_square_names).sweep_number.sort_values().values
 
     ssq_sweep_numbers = data_set.filtered_sweep_table(clamp_mode=data_set.CURRENT_CLAMP,
-                                                      passing_only=True,
                                                       stimuli=ontology.short_square_names).sweep_number.sort_values().values
 
     ramp_sweep_numbers = data_set.filtered_sweep_table(clamp_mode=data_set.CURRENT_CLAMP,
-                                                       passing_only=True,
                                                        stimuli=ontology.ramp_names).sweep_number.sort_values().values
 
     if subthresh_min_amp is None:

--- a/ipfx/ephys_data_set.py
+++ b/ipfx/ephys_data_set.py
@@ -202,6 +202,12 @@ class EphysDataSet(object):
         """
         raise NotImplementedError
 
+    def get_clamp_mode(self,stimulus_number):
+        raise NotImplementedError
+
+    def get_stimulus_code(self,stimulus_number):
+        raise NotImplementedError
+
     def get_stimulus_name(self, stim_code):
 
         if not self.ontology:

--- a/ipfx/ephys_data_set.py
+++ b/ipfx/ephys_data_set.py
@@ -14,7 +14,6 @@ class EphysDataSet(object):
     STIMULUS_AMPLITUDE = 'stimulus_amplitude'
     STIMULUS_NAME = 'stimulus_name'
     SWEEP_NUMBER = 'sweep_number'
-    PASSED = 'passed'
     CLAMP_MODE = 'clamp_mode'
 
     COLUMN_NAMES = [STIMULUS_UNITS,
@@ -23,7 +22,6 @@ class EphysDataSet(object):
                     STIMULUS_NAME,
                     CLAMP_MODE,
                     SWEEP_NUMBER,
-                    PASSED
                     ]
 
     LONG_SQUARE = 'long_square'
@@ -49,7 +47,6 @@ class EphysDataSet(object):
 
     def filtered_sweep_table(self,
                              clamp_mode=None,
-                             passing_only=False,
                              stimuli=None,
                              stimuli_exclude=None,
                              ):
@@ -58,10 +55,6 @@ class EphysDataSet(object):
 
         if clamp_mode:
             mask = st[self.CLAMP_MODE] == clamp_mode
-            st = st[mask.astype(bool)]
-
-        if passing_only:
-            mask = st[self.PASSED]
             st = st[mask.astype(bool)]
 
         if stimuli:

--- a/ipfx/ephys_data_set.py
+++ b/ipfx/ephys_data_set.py
@@ -1,6 +1,5 @@
 import warnings
 import logging
-import re
 import pandas as pd
 import numpy as np
 from ipfx.stimulus import StimulusOntology
@@ -172,14 +171,6 @@ class EphysDataSet(object):
 
         raise NotImplementedError
 
-    def modify_api_sweep_info(self, sweep_list):
-        return [{EphysDataSet.SWEEP_NUMBER: s['sweep_number'],
-                 EphysDataSet.STIMULUS_UNITS: s['stimulus_units'],
-                 EphysDataSet.STIMULUS_AMPLITUDE: s['stimulus_absolute_amplitude'],
-                 EphysDataSet.STIMULUS_CODE: re.sub(r"\[\d+\]", "", s['stimulus_description']),
-                 EphysDataSet.STIMULUS_NAME: s['stimulus_name'],
-                 EphysDataSet.CLAMP_MODE: s['clamp_mode'],
-                 EphysDataSet.PASSED: True} for s in sweep_list]
 
     def get_sweep_data(self, sweep_number):
         """

--- a/ipfx/ephys_data_set.py
+++ b/ipfx/ephys_data_set.py
@@ -37,12 +37,29 @@ class EphysDataSet(object):
         self.ontology = ontology if ontology else StimulusOntology()
         self.validate_stim = validate_stim
 
-    def build_sweep_table(self,sweep_meta_data=None):
+    def build_sweep_table(self, sweep_info=None):
 
-        if sweep_meta_data:
-            self.sweep_table = pd.DataFrame.from_records(sweep_meta_data)
+        if sweep_info:
+            self.add_clamp_mode(sweep_info)
+            self.sweep_table = pd.DataFrame.from_records(sweep_info)
         else:
             self.sweep_table = pd.DataFrame(columns=self.COLUMN_NAMES)
+
+    def add_clamp_mode(self, sweep_info):
+        """
+        Check if clamp mode is available and otherwise detect it
+        Parameters
+        ----------
+        sweep_info
+
+        Returns
+        -------
+
+        """
+
+        for sweep_record in sweep_info:
+            sweep_number = sweep_record["sweep_number"]
+            sweep_record[self.CLAMP_MODE] = self.get_clamp_mode(sweep_number)
 
     def filtered_sweep_table(self,
                              clamp_mode=None,

--- a/ipfx/ephys_data_set.py
+++ b/ipfx/ephys_data_set.py
@@ -99,7 +99,7 @@ class EphysDataSet(object):
 
         return sweeps.sweep_number.values[-1]
 
-    def get_sweep_meta_data(self, sweep_number):
+    def get_sweep_record(self, sweep_number):
         """
         Parameters
         ----------
@@ -107,7 +107,7 @@ class EphysDataSet(object):
 
         Returns
         -------
-        sweep_meta_data: dict of sweep properties
+        sweep_record: dict of sweep properties
         """
 
         st = self.sweep_table
@@ -133,13 +133,13 @@ class EphysDataSet(object):
         """
 
         sweep_data = self.get_sweep_data(sweep_number)
-        sweep_meta_data = self.get_sweep_meta_data(sweep_number)
+        sweep_record = self.get_sweep_record(sweep_number)
         sampling_rate = sweep_data['sampling_rate']
         dt = 1. / sampling_rate
         t = np.arange(0, len(sweep_data['stimulus'])) * dt
 
         epochs = sweep_data.get('epochs')
-        clamp_mode = sweep_meta_data['clamp_mode']
+        clamp_mode = sweep_record['clamp_mode']
         if clamp_mode == "VoltageClamp":
             v = sweep_data['stimulus']
             i = sweep_data['response']
@@ -178,7 +178,7 @@ class EphysDataSet(object):
     def aligned_sweeps(self, sweep_numbers, stim_onset_delta):
         raise NotImplementedError
 
-    def extract_sweep_meta_data(self):
+    def extract_sweep_stim_info(self):
         """
         Returns
         -------

--- a/ipfx/hbg_dataset.py
+++ b/ipfx/hbg_dataset.py
@@ -11,19 +11,16 @@ class HBGDataSet(EphysDataSet):
         super(HBGDataSet, self).__init__(ontology, validate_stim)
         self.nwb_data = nwb_reader.create_nwb_reader(nwb_file)
 
-        if sweep_info is not None:
-            sweep_info = self.modify_api_sweep_info(
-                sweep_info) if api_sweeps else sweep_info
-        else:
-            sweep_info = self.extract_sweep_meta_data()
+        if sweep_info is None:
+            sweep_info = self.extract_sweep_stim_info()
 
-        self.sweep_table = pd.DataFrame.from_records(sweep_info)
+        self.build_sweep_table(sweep_info)
 
-    def extract_sweep_meta_data(self):
+    def extract_sweep_stim_info(self):
 
         logging.debug("Build sweep table")
 
-        sweep_props = []
+        sweep_info = []
 
         def get_finite_or_none(d, key):
 

--- a/ipfx/plot_qc_figures.py
+++ b/ipfx/plot_qc_figures.py
@@ -447,8 +447,7 @@ def plot_instantaneous_threshold_thumbnail(data_set, sweep_numbers, cell_feature
 
 def plot_ramp_figures(data_set, cell_features, lims_features, sweep_features, image_dir, sizes, cell_image_files):
 
-    ramps_sweeps = data_set.filtered_sweep_table(passing_only=True,
-                                                 current_clamp=data_set.CURRENT_CLAMP,
+    ramps_sweeps = data_set.filtered_sweep_table(clamp_mode=data_set.CURRENT_CLAMP,
                                                  stimuli=data_set.ontology.ramp_names)
     ramps_sweeps = np.sort(ramps_sweeps['sweep_number'].values)
 

--- a/ipfx/sweep_props.py
+++ b/ipfx/sweep_props.py
@@ -41,6 +41,11 @@ def drop_tagged_sweeps(sweep_features):
     sweep_features[:] = [sf for sf in sweep_features if not sf["tags"]]
 
 
+def drop_failed_sweeps(sweep_features):
+
+    sweep_features[:] = [sf for sf in sweep_features if sf["passed"]]
+
+
 def remove_sweep_feature(feature_name,sweep_features):
 
     for sf in sweep_features:

--- a/ipfx/sweep_props.py
+++ b/ipfx/sweep_props.py
@@ -1,4 +1,7 @@
 import logging
+import re
+
+from .ephys_data_set import EphysDataSet
 
 
 def override_auto_sweep_states(manual_sweep_states,sweep_states):
@@ -108,3 +111,11 @@ def count_sweep_states(sweep_states):
 
     return num_passed_sweeps, num_sweeps
 
+
+def modify_sweep_info_keys(sweep_list):
+    return [{EphysDataSet.SWEEP_NUMBER: s['sweep_number'],
+             EphysDataSet.STIMULUS_UNITS: s['stimulus_units'],
+             EphysDataSet.STIMULUS_AMPLITUDE: s['stimulus_absolute_amplitude'],
+             EphysDataSet.STIMULUS_CODE: re.sub(r"\[\d+\]", "", s['stimulus_description']),
+             EphysDataSet.STIMULUS_NAME: s['stimulus_name'],
+             } for s in sweep_list]

--- a/tests/test_aibs_data_set.py
+++ b/tests/test_aibs_data_set.py
@@ -1,0 +1,64 @@
+import pytest
+
+from ipfx.aibs_data_set import AibsDataSet
+from ipfx.aibs_data_set import EphysDataSet
+import ipfx.sweep_props as sp
+from helpers_for_tests import compare_dicts
+
+
+@pytest.mark.parametrize('NWB_file', ['H18.03.315.11.11.01.05.nwb'], indirect=True)
+def test_validate_required_sweep_info(NWB_file):
+
+    sweep_info = [{"sweep_number": 0}]
+    dataset = AibsDataSet(sweep_info, nwb_file=NWB_file, api_sweeps=False)
+
+    assert list(dataset.sweep_table).sort() == dataset.COLUMN_NAMES.sort()
+
+
+def test_modify_sweep_info_keys():
+    d = [{"sweep_number": 123,
+          "stimulus_units": "abcd",
+          "stimulus_absolute_amplitude": 456,
+          "stimulus_description": "efgh[4711]",
+          "stimulus_name": "hijkl",
+          }]
+
+    result = sp.modify_sweep_info_keys(d)
+
+    expected = [{EphysDataSet.SWEEP_NUMBER: 123,
+                 EphysDataSet.STIMULUS_UNITS: "abcd",
+                 EphysDataSet.STIMULUS_AMPLITUDE: 456,
+                 EphysDataSet.STIMULUS_CODE: "efgh",
+                 EphysDataSet.STIMULUS_NAME: "hijkl",
+                 }]
+
+    assert len(expected) == len(result)
+    compare_dicts(expected[0], result[0])
+
+
+@pytest.mark.parametrize('NWB_file', ['H18.03.315.11.11.01.05.nwb'], indirect=True)
+def test_get_clamp_mode(NWB_file):
+    dataset = AibsDataSet(nwb_file=NWB_file)
+
+    assert dataset.get_clamp_mode(0) == dataset.VOLTAGE_CLAMP
+
+
+@pytest.mark.parametrize('NWB_file', ['H18.03.315.11.11.01.05.nwb'], indirect=True)
+def test_get_stimulus_units(NWB_file):
+
+    dataset = AibsDataSet(nwb_file=NWB_file)
+    assert dataset.get_stimulus_units(0) == "mV"
+
+
+@pytest.mark.parametrize('NWB_file', ['H18.03.315.11.11.01.05.nwb'], indirect=True)
+def test_get_stimulus_code(NWB_file):
+
+    dataset = AibsDataSet(nwb_file=NWB_file)
+    assert dataset.get_stimulus_code(0) == "EXTPSMOKET180424"
+
+
+@pytest.mark.parametrize('NWB_file', ['H18.03.315.11.11.01.05.nwb'], indirect=True)
+def test_get_stimulus_code_ext(NWB_file):
+    dataset = AibsDataSet(nwb_file=NWB_file)
+
+    assert dataset.get_stimulus_code_ext("EXTPSMOKET180424",0) == "EXTPSMOKET180424[0]"

--- a/tests/test_ephys_data_set.py
+++ b/tests/test_ephys_data_set.py
@@ -35,7 +35,7 @@ def get_empty_dataset():
 
     default_ontology = StimulusOntology()
     dataset = EphysDataSet(default_ontology)
-    dataset.build_sweep_table(sweep_meta_data=[])
+    dataset.build_sweep_table(sweep_info=[])
 
     return dataset
 
@@ -91,7 +91,7 @@ def test_filtered_sweep_table_stimuli_exclude():
     assert sweeps["sweep_number"].values == 0
 
 
-def test_get_sweep_meta_data():
+def test_get_sweep_record():
 
     d = get_sweep_table_dict()
     expected = {}
@@ -99,7 +99,7 @@ def test_get_sweep_meta_data():
         expected[k] = d[k][1]
 
     ds = get_dataset()
-    actual = ds.get_sweep_meta_data(5)
+    actual = ds.get_sweep_record(5)
     compare_dicts(expected, actual)
 
 
@@ -129,35 +129,22 @@ def test_aligned_sweeps_raises():
         ds = get_dataset()
         ds.aligned_sweeps([5], 0.0)
 
-
-def test_extract_sweep_meta_data_raises():
+def test_get_stimulus_code_raises():
     with pytest.raises(NotImplementedError):
         ds = get_dataset()
-        ds.extract_sweep_meta_data()
+        ds.get_stimulus_code(0)
+
+def test_get_clamp_mode_raises():
+    with pytest.raises(NotImplementedError):
+        ds = get_dataset()
+        ds.get_clamp_mode(0)
+
+def test_extract_sweep_stim_info_raises():
+    with pytest.raises(NotImplementedError):
+        ds = get_dataset()
+        ds.extract_sweep_stim_info()
 
 
-def test_modify_api_sweep_info():
-    d = [{"sweep_number": 123,
-          "stimulus_units": "abcd",
-          "stimulus_absolute_amplitude": 456,
-          "stimulus_description": "efgh[4711]",
-          "stimulus_name": "hijkl",
-          "clamp_mode": "mnopqr"
-          }]
-
-    ds = get_dataset()
-    result = ds.modify_api_sweep_info(d)
-
-    expected = [{EphysDataSet.SWEEP_NUMBER: 123,
-                 EphysDataSet.STIMULUS_UNITS: "abcd",
-                 EphysDataSet.STIMULUS_AMPLITUDE: 456,
-                 EphysDataSet.STIMULUS_CODE: "efgh",
-                 EphysDataSet.STIMULUS_NAME: "hijkl",
-                 EphysDataSet.CLAMP_MODE: "mnopqr",
-                 EphysDataSet.PASSED: True}]
-
-    assert len(expected) == len(result)
-    compare_dicts(expected[0], result[0])
 
 
 def test_get_stimulus_name():

--- a/tests/test_hbg_dataset.py
+++ b/tests/test_hbg_dataset.py
@@ -57,5 +57,28 @@ def test_main_dat(ontology, NWB_file):
                 }
 
     # only compare one sweep
-    sweep_meta_data = dataset.get_sweep_meta_data(10101)
-    compare_dicts(expected, sweep_meta_data)
+    sweep_record = dataset.get_sweep_record(10101)
+    compare_dicts(expected, sweep_record)
+
+
+@pytest.mark.parametrize('ontology, NWB_file', [(None, 'H18.28.015.11.14.nwb')], indirect=True)
+def test_get_clamp_mode(ontology, NWB_file):
+
+    dataset = HBGDataSet(nwb_file=NWB_file, ontology=ontology)
+    assert dataset.get_clamp_mode(10101) == dataset.VOLTAGE_CLAMP
+
+
+@pytest.mark.parametrize('ontology, NWB_file', [(None, 'H18.28.015.11.14.nwb')], indirect=True)
+def test_get_stimulus_units(ontology, NWB_file):
+
+    dataset = HBGDataSet(nwb_file=NWB_file, ontology=ontology)
+    assert dataset.get_stimulus_units(10101) == "V"
+
+
+@pytest.mark.parametrize('ontology, NWB_file', [(None, 'H18.28.015.11.14.nwb')], indirect=True)
+def test_get_stimulus_code(ontology, NWB_file):
+
+    dataset = HBGDataSet(nwb_file=NWB_file, ontology=ontology)
+    assert dataset.get_stimulus_code(10101) == u'extpinbath'
+
+


### PR DESCRIPTION
At the stage of the feature extraction, the `sweep_record` is missing `clamp_mode` information.
Thus, adding a method for determining the clamp mode. Call it before building a sweep_table.
I had to refactor AibsDataSet and HBGDataSet to factor out individual functions for determining sweep properties.

Resolves #203, #205  