### PR TITLE
fix wrong name for certain noise stimuli

### DIFF
--- a/ipfx/defaults/stimulus_ontology.json
+++ b/ipfx/defaults/stimulus_ontology.json
@@ -1830,7 +1830,8 @@
     ],
     [
       "name",
-      "Short Square"
+      "Noise",
+      "Noise 1"
     ]
   ],
   [
@@ -1840,7 +1841,8 @@
     ],
     [
       "name",
-      "Short Square"
+      "Noise",
+      "Noise 2"
     ],
     [
       "code",


### PR DESCRIPTION
Fixes noise stimuli wrongly marked as short squares