### PR TITLE
More qc-related spike filtering options

### DIFF
--- a/ipfx/bin/run_feature_vector_extraction.py
+++ b/ipfx/bin/run_feature_vector_extraction.py
@@ -263,6 +263,7 @@ def preprocess_short_square_sweeps(data_set, sweep_numbers, extra_dur=0.2, spike
                                                   est_window = [ssq_start, ssq_start + 0.001],
                                                   start=ssq_start,
                                                   end=ssq_end + spike_window,
+                                                  reject_at_stim_start_interval=0.0002,
                                                   **dsf.detection_parameters(data_set.SHORT_SQUARE))
     ssq_an = spa.ShortSquareAnalysis(ssq_spx, ssq_spfx)
     ssq_features = ssq_an.analyze(ssq_sweeps)

--- a/ipfx/bin/run_feature_vector_extraction.py
+++ b/ipfx/bin/run_feature_vector_extraction.py
@@ -238,8 +238,9 @@ def preprocess_long_square_sweeps(data_set, sweep_numbers, extra_dur=0.2, subthr
 
     lsq_spx, lsq_spfx = dsf.extractors_for_sweeps(
         lsq_sweeps,
-        start = lsq_start,
-        end = lsq_end,
+        start=lsq_start,
+        end=lsq_end,
+        min_peak=-25,
         **dsf.detection_parameters(data_set.LONG_SQUARE)
     )
     lsq_an = spa.LongSquareAnalysis(lsq_spx, lsq_spfx,
@@ -249,7 +250,7 @@ def preprocess_long_square_sweeps(data_set, sweep_numbers, extra_dur=0.2, subthr
     return lsq_sweeps, lsq_features, lsq_start, lsq_end, lsq_spx
 
 
-def preprocess_short_square_sweeps(data_set, sweep_numbers, extra_dur=0.2, spike_window=0.01):
+def preprocess_short_square_sweeps(data_set, sweep_numbers, extra_dur=0.2, spike_window=0.05):
     if len(sweep_numbers) == 0:
         raise er.FeatureError("No short square sweeps available for feature extraction")
 
@@ -384,7 +385,8 @@ def data_for_specimen_id(specimen_id, sweep_qc_option, data_source,
         ssq_ap_v, ssq_ap_dv = fv.first_ap_vectors(spiking_ssq_sweep_list,
             spiking_ssq_info_list,
             target_sampling_rate=target_sampling_rate,
-            window_length=ap_window_length)
+            window_length=ap_window_length,
+            skip_clipped=True)
 
         rheo_ind = lsq_features["rheobase_sweep"].name
         sweep = lsq_sweeps.sweeps[rheo_ind]

--- a/ipfx/data_set_features.py
+++ b/ipfx/data_set_features.py
@@ -78,6 +78,8 @@ def detection_parameters(stimulus_name):
 
 def extractors_for_sweeps(sweep_set,
                           dv_cutoff=20., thresh_frac=0.05,
+                          reject_at_stim_start_interval=0,
+                          min_peak=-30,
                           thresh_frac_floor=None,
                           est_window=None,
                           start=None, end=None):
@@ -89,6 +91,7 @@ def extractors_for_sweeps(sweep_set,
 
     dv_cutoff : float
     thresh_frac :
+    reject_at_stim_start_interval :
     thresh_frac_floor
     est_window :
     start :
@@ -109,7 +112,13 @@ def extractors_for_sweeps(sweep_set,
     if thresh_frac_floor is not None:
         thresh_frac = max(thresh_frac_floor, thresh_frac)
 
-    sfx = SpikeFeatureExtractor(dv_cutoff=dv_cutoff, thresh_frac=thresh_frac, start=start, end=end)
+    sfx = SpikeFeatureExtractor(dv_cutoff=dv_cutoff,
+        thresh_frac=thresh_frac,
+        start=start,
+        end=end,
+        min_peak=min_peak,
+        reject_at_stim_start_interval=reject_at_stim_start_interval)
+
     stfx = SpikeTrainFeatureExtractor(start, end)
 
     return sfx, stfx

--- a/ipfx/feature_extractor.py
+++ b/ipfx/feature_extractor.py
@@ -60,7 +60,7 @@ class SpikeFeatureExtractor(object):
 
     def __init__(self, start=None, end=None, filter=10.,
                  dv_cutoff=20., max_interval=0.005, min_height=2., min_peak=-30.,
-                 thresh_frac=0.05):
+                 thresh_frac=0.05, reject_at_stim_start_interval=0):
         """Initialize SweepFeatures object.-
 
         Parameters
@@ -76,6 +76,7 @@ class SpikeFeatureExtractor(object):
         min_height : minimum acceptable height from threshold to peak in mV (optional, default 2)
         min_peak : minimum acceptable absolute peak level in mV (optional, default -30)
         thresh_frac : fraction of average upstroke for threshold calculation (optional, default 0.05)
+        reject_at_stim_start_interval : duration of window after start to reject potential spikes (optional, default 0)
         """
         self.start = start
         self.end = end
@@ -85,6 +86,7 @@ class SpikeFeatureExtractor(object):
         self.min_height = min_height
         self.min_peak = min_peak
         self.thresh_frac = thresh_frac
+        self.reject_at_stim_start_interval = reject_at_stim_start_interval
 
     def process(self, t, v, i):
         dvdt = tsu.calculate_dvdt(v, t, self.filter)
@@ -107,8 +109,9 @@ class SpikeFeatureExtractor(object):
                                                  dvdt=dvdt)
 
         thresholds, peaks, upstrokes, clipped = spkd.check_thresholds_and_peaks(v, t, thresholds, peaks,
-                                                                     upstrokes, self.end, self.max_interval,
-                                                                     dvdt=dvdt)
+                                                                     upstrokes, self.start, self.end, self.max_interval,
+                                                                     dvdt=dvdt,
+                                                                     reject_at_stim_start_interval=self.reject_at_stim_start_interval)
         if not thresholds.size:
             # Save time if no spikes detected
             return DataFrame()

--- a/ipfx/feature_extractor.py
+++ b/ipfx/feature_extractor.py
@@ -265,8 +265,8 @@ class SpikeTrainFeatureExtractor(object):
         self.sag_baseline_interval = sag_baseline_interval
         self.peak_width = peak_width
 
-    def process(self, t, v, i, spikes_df, extra_features=None):
-        features = strf.basic_spike_train_features(t, spikes_df, self.start, self.end)
+    def process(self, t, v, i, spikes_df, extra_features=None, exclude_clipped=False):
+        features = strf.basic_spike_train_features(t, spikes_df, self.start, self.end, exclude_clipped=exclude_clipped)
 
         if self.start is None:
             self.start = t[0]

--- a/ipfx/spike_train_features.py
+++ b/ipfx/spike_train_features.py
@@ -6,13 +6,16 @@ from . import spike_features as spkf
 from . import error as er
 
 
-def basic_spike_train_features(t, spikes_df, start, end):
+def basic_spike_train_features(t, spikes_df, start, end, exclude_clipped=False):
     features = {}
     if len(spikes_df) == 0 or spikes_df.empty:
         features["avg_rate"] = 0
         return features
 
     thresholds = spikes_df["threshold_index"].values.astype(int)
+    if exclude_clipped:
+        mask = spikes_df["clipped"].values.astype(bool)
+        thresholds = thresholds[~mask]
     isis = get_isis(t, thresholds)
     with warnings.catch_warnings():
         # ignore mean of empty slice warnings here

--- a/ipfx/stimulus_protocol_analysis.py
+++ b/ipfx/stimulus_protocol_analysis.py
@@ -69,20 +69,20 @@ class StimulusProtocolAnalysis(object):
             output[mf] = np.nanmean(mfd)
         return output
 
-    def analyze_basic_features(self, sweep_set, extra_sweep_features=None):
+    def analyze_basic_features(self, sweep_set, extra_sweep_features=None, exclude_clipped=False):
         self._spikes_set = []
         for sweep in sweep_set.sweeps:
             self._spikes_set.append(self.spx.process(sweep.t, sweep.v, sweep.i))
 
-        self._sweep_features = pd.DataFrame([ self.sptx.process(sweep.t, sweep.v, sweep.i, spikes, extra_sweep_features)
+        self._sweep_features = pd.DataFrame([ self.sptx.process(sweep.t, sweep.v, sweep.i, spikes, extra_sweep_features, exclude_clipped=exclude_clipped)
                                               for sweep, spikes in zip(sweep_set.sweeps, self._spikes_set) ])
 
     def reset_basic_features(self):
         self._spikes_set = None
         self._sweep_features = None
 
-    def analyze(self, sweep_set, extra_sweep_features=None):
-        self.analyze_basic_features(sweep_set, extra_sweep_features=extra_sweep_features)
+    def analyze(self, sweep_set, extra_sweep_features=None, exclude_clipped=False):
+        self.analyze_basic_features(sweep_set, extra_sweep_features=extra_sweep_features, exclude_clipped=exclude_clipped)
         return {"spikes_set": self._spikes_set, "sweeps": self._sweep_features}
 
     def as_dict(self, features, extra_params=None):
@@ -274,7 +274,7 @@ class ShortSquareAnalysis(StimulusProtocolAnalysis):
 
     def analyze(self, sweep_set):
         extra_sweep_features = [ "stim_amp" ]
-        features = super(ShortSquareAnalysis, self).analyze(sweep_set, extra_sweep_features=extra_sweep_features)
+        features = super(ShortSquareAnalysis, self).analyze(sweep_set, extra_sweep_features=extra_sweep_features, exclude_clipped=True)
 
         spiking_sweep_features = self.suprathreshold_sweep_features()
 


### PR DESCRIPTION
Gives more flexibility to filter out certain spikes during feature extraction, including:
- ability to reject spikes detected with start at the start of the stimulus interval (can occur with strong short square stimuli, for example)
- can exclude clipped spikes from basic sweep feature calculations (incorrect spike detection can occur when sweep is terminated early)
- uses these new features in `run_feature_vector_extraction` script