### PR TITLE
Get data from nwb in base SI units

### DIFF
--- a/ipfx/aibs_data_set.py
+++ b/ipfx/aibs_data_set.py
@@ -85,18 +85,8 @@ class AibsDataSet(EphysDataSet):
 
     def get_stimulus_units(self, sweep_num):
 
-        attrs = self.nwb_data.get_sweep_attrs(sweep_num)
-        ancestry = attrs["ancestry"]
-        # stim units are based on timeseries type
-        time_series_type = to_str(ancestry[-1])
-        if "CurrentClamp" in time_series_type:
-            units = 'pA'
-        elif "VoltageClamp" in time_series_type:
-            units = 'mV'
-        else:
-            raise Exception("Unable to determine clamp mode in {}".format(sweep_num))
-
-        return units
+        unit_str = self.nwb_data.get_stimulus_unit(sweep_num)
+        return unit_str
 
     def get_clamp_mode(self, sweep_num):
 

--- a/ipfx/ephys_data_set.py
+++ b/ipfx/ephys_data_set.py
@@ -140,6 +140,7 @@ class EphysDataSet(object):
 
         epochs = sweep_data.get('epochs')
         clamp_mode = sweep_record['clamp_mode']
+
         if clamp_mode == "VoltageClamp":
             v = sweep_data['stimulus']
             i = sweep_data['response']
@@ -148,6 +149,9 @@ class EphysDataSet(object):
             i = sweep_data['stimulus']
         else:
             raise Exception("Unable to determine clamp mode for sweep " + sweep_number)
+
+        v *= 1.0e3    # convert units V->mV
+        i *= 1.0e12   # convert units A->pA
 
         if len(sweep_data['stimulus']) != len(sweep_data['response']):
             warnings.warn("Stimulus duration {} is not equal reponse duration {}".

--- a/ipfx/nwb_reader.py
+++ b/ipfx/nwb_reader.py
@@ -388,17 +388,6 @@ class NwbPipelineReader(NwbReader):
 
     def get_sweep_data(self, sweep_number):
         """
-        Retrieve the stimulus, response, index_range, and sampling rate
-        for a particular sweep.  This method hides the NWB file's distinction
-        between a "Sweep" and an "Experiment".  An experiment is a subset of
-        of a sweep that excludes the initial test pulse.  It also excludes
-        any erroneous response data at the end of the sweep (usually for
-        ramp sweeps, where recording was terminated mid-stimulus).
-        Some sweeps do not have an experiment, so full data arrays are
-        returned.  Sweeps that have an experiment return full data arrays
-        (include the test pulse) with any erroneous data trimmed from the
-        back of the sweep. Data is returned in mV and pA.
-        Partially borrowed from the AllenSDK.get_sweep()
 
         Parameters
         ----------
@@ -407,10 +396,7 @@ class NwbPipelineReader(NwbReader):
         Returns
         -------
         dict
-            A dictionary with 'stimulus', 'response', 'index_range', and
-            'sampling_rate' elements.  The index range is a 2-tuple where
-            the first element indicates the end of the test pulse and the
-            second index is the end of valid response data.
+            with values for 'stimulus', 'response', 'stimulus_unit', 'sampling_rate'
         """
         with h5py.File(self.nwb_file, 'r') as f:
 
@@ -452,6 +438,7 @@ class NwbPipelineReader(NwbReader):
                 'stimulus_unit': stimulus_unit,
                 'sampling_rate': hz
             }
+
 
     def get_sweep_number(self, sweep_name):
 

--- a/ipfx/nwb_reader.py
+++ b/ipfx/nwb_reader.py
@@ -67,6 +67,19 @@ class NwbReader(object):
 
         return recording_date
 
+    def get_stimulus_unit(self, sweep_number):
+
+        sweep_map = self.get_sweep_map(sweep_number)
+
+        with h5py.File(self.nwb_file, 'r') as f:
+            sweep_stimulus = f[self.stimulus_path][sweep_map["stimulus_group"]]
+            stimulus_dataset = sweep_stimulus["data"]
+
+            unit = NwbReader.get_unit_name(stimulus_dataset.attrs)
+            unit_str = NwbReader.get_long_unit_name(unit)
+
+            return unit_str
+
     @staticmethod
     def get_unit_name(stim_attrs):
         if 'unit' in stim_attrs:

--- a/ipfx/nwb_reader.py
+++ b/ipfx/nwb_reader.py
@@ -417,17 +417,6 @@ class NwbPipelineReader(NwbReader):
             unit = NwbReader.get_unit_name(stimulus_dataset.attrs)
             unit_str = NwbReader.get_long_unit_name(unit)
 
-            if unit_str == "Amps":
-                response *= 1e3,  # voltage, convert units V->mV
-                stimulus *= 1e12,  # current, convert units A->pA
-
-            elif unit_str == "Volts":
-                response *= 1e12,  # current, convert units A->pA
-                stimulus *= 1e3,  # voltage, convert units V->mV
-
-            else:
-                raise ValueError("Unknown stimulus unit")
-
             hz = 1.0 * swp['stimulus/timeseries']['starting_time'].attrs['rate']
 
             return {
@@ -485,12 +474,17 @@ class NwbMiesReader(NwbReader):
         with h5py.File(self.nwb_file, 'r') as f:
             sweep_response = f[self.acquisition_path][sweep_map["acquisition_group"]]
             response_dataset = sweep_response["data"]
+            response_conversion = float(response_dataset.attrs["conversion"])
+
             hz = 1.0 * sweep_response["starting_time"].attrs['rate']
             sweep_stimulus = f[self.stimulus_path][sweep_map["stimulus_group"]]
             stimulus_dataset = sweep_stimulus["data"]
 
-            response = response_dataset[...]
-            stimulus = stimulus_dataset[...]
+            stimulus_conversion = float(stimulus_dataset.attrs["conversion"])
+
+            stimulus = stimulus_dataset[...] * stimulus_conversion
+            response = response_dataset[...] * response_conversion
+
 
             unit = NwbReader.get_unit_name(stimulus_dataset.attrs)
             unit_str = NwbReader.get_long_unit_name(unit)

--- a/tests/test_aibs_data_set.py
+++ b/tests/test_aibs_data_set.py
@@ -53,7 +53,7 @@ def test_get_stimulus_units(NWB_file):
 
     default_ontology = StimulusOntology(ju.read(StimulusOntology.DEFAULT_STIMULUS_ONTOLOGY_FILE))
     dataset = AibsDataSet(nwb_file=NWB_file, ontology=default_ontology)
-    assert dataset.get_stimulus_units(0) == "mV"
+    assert dataset.get_stimulus_units(0) == "Volts"
 
 
 @pytest.mark.parametrize('NWB_file', ['H18.03.315.11.11.01.05.nwb'], indirect=True)

--- a/tests/test_specimens.csv
+++ b/tests/test_specimens.csv
@@ -1,7 +1,7 @@
 input_json output_json
-/allen/aibs/informatics/module_test_data/ipfx/test_specimens/478407134/pipeline_input_230.json /allen/aibs/informatics/module_test_data/ipfx/test_specimens/478407134/pipeline_output_229.json
-/allen/aibs/informatics/module_test_data/ipfx/test_specimens/500844783/pipeline_input_230.json /allen/aibs/informatics/module_test_data/ipfx/test_specimens/500844783/pipeline_output_229.json
-/allen/aibs/informatics/module_test_data/ipfx/test_specimens/Npr3-IRES2-CreSst-IRES-FlpOAi65-401243.04.01.01/pipeline_input_230.json /allen/aibs/informatics/module_test_data/ipfx/test_specimens/Npr3-IRES2-CreSst-IRES-FlpOAi65-401243.04.01.01/pipeline_output_229.json
-/allen/aibs/informatics/module_test_data/ipfx/test_specimens/Sst-IRES-CreAi14-395722.01.01.01/pipeline_input_230.json /allen/aibs/informatics/module_test_data/ipfx/test_specimens/Sst-IRES-CreAi14-395722.01.01.01/pipeline_output_229.json
-/allen/aibs/informatics/module_test_data/ipfx/test_specimens/509604672/pipeline_input_230.json /allen/aibs/informatics/module_test_data/ipfx/test_specimens/509604672/pipeline_output_229.json
-/allen/aibs/informatics/module_test_data/ipfx/test_specimens/H18.03.315.11.11.01.05/pipeline_input_230.json /allen/aibs/informatics/module_test_data/ipfx/test_specimens/H18.03.315.11.11.01.05/pipeline_output_229.json
+/allen/aibs/informatics/module_test_data/ipfx/test_specimens/478407134/pipeline_input_230.json /allen/aibs/informatics/module_test_data/ipfx/test_specimens/478407134/pipeline_output_cl.json
+/allen/aibs/informatics/module_test_data/ipfx/test_specimens/500844783/pipeline_input_230.json /allen/aibs/informatics/module_test_data/ipfx/test_specimens/500844783/pipeline_output_cl.json
+/allen/aibs/informatics/module_test_data/ipfx/test_specimens/Npr3-IRES2-CreSst-IRES-FlpOAi65-401243.04.01.01/pipeline_input_230.json /allen/aibs/informatics/module_test_data/ipfx/test_specimens/Npr3-IRES2-CreSst-IRES-FlpOAi65-401243.04.01.01/pipeline_output_cl.json
+/allen/aibs/informatics/module_test_data/ipfx/test_specimens/Sst-IRES-CreAi14-395722.01.01.01/pipeline_input_230.json /allen/aibs/informatics/module_test_data/ipfx/test_specimens/Sst-IRES-CreAi14-395722.01.01.01/pipeline_output_cl.json
+/allen/aibs/informatics/module_test_data/ipfx/test_specimens/509604672/pipeline_input_230.json /allen/aibs/informatics/module_test_data/ipfx/test_specimens/509604672/pipeline_output_cl.json
+/allen/aibs/informatics/module_test_data/ipfx/test_specimens/H18.03.315.11.11.01.05/pipeline_input_230.json /allen/aibs/informatics/module_test_data/ipfx/test_specimens/H18.03.315.11.11.01.05/pipeline_output_cl.json


### PR DESCRIPTION
Both data and unit names must be in base SI units. 
For example, we should have data in Volts (not mV) 