### PR TITLE
Nwb2 regression test

### DIFF
--- a/ipfx/bin/run_nwb1_to_nwb2_conversion.py
+++ b/ipfx/bin/run_nwb1_to_nwb2_conversion.py
@@ -4,6 +4,7 @@ import os
 import argschema as args
 from ipfx.x_to_nwb.NWBConverter import NWBConverter
 
+
 class ConvertNWBParameters(args.ArgSchema):
     input_nwb_file = args.fields.InputFile(description="input nwb1 file", required=True)
 
@@ -29,8 +30,9 @@ def main():
     if not os.path.exists(nwb1_file_name):
         raise ValueError(f"The file {nwb1_file_name} does not exist.")
 
-    NWBConverter(input_file = nwb1_file_name,
-                 output_file= nwb2_file_name)
+    NWBConverter(nwb1_file_name,
+                 nwb2_file_name,
+                 )
 
 
 if __name__ == "__main__":

--- a/ipfx/x_to_nwb/NWBConverter.py
+++ b/ipfx/x_to_nwb/NWBConverter.py
@@ -26,7 +26,7 @@ class NWBConverter:
     I_CLAMP_MODE = "current_clamp"
     PLACEHOLDER = "PLACEHOLDER"
 
-    def __init__(self, input_file, output_file, compression=True):
+    def __init__(self, input_file, output_file):
         """
         Convert NWB v1 to v2
 
@@ -42,7 +42,6 @@ class NWBConverter:
         electrode = nwb_file.create_ic_electrode(name="elec0",
                                                  description=' some kind of electrode',
                                                  device=device)
-
 
         for i in self.create_stimulus_series(electrode):
             nwb_file.add_stimulus(i)

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ argschema
 allensdk
 dictdiffer
 pyabf==2.0.25
-pynwb>=1.0.0
+pynwb==1.0.2
 six
 watchdog
 pg8000

--- a/tests/test_nwb1_nwb2_conversion.py
+++ b/tests/test_nwb1_nwb2_conversion.py
@@ -4,6 +4,35 @@ import pytest
 from ipfx.x_to_nwb.NWBConverter import NWBConverter
 from .helpers_for_tests import diff_h5, validate_nwb
 from ipfx.bin.run_nwb1_to_nwb2_conversion import make_nwb2_file_name
+from hdmf import Container
+
+
+class TestNWBConverter(NWBConverter):
+
+    @staticmethod
+    def undefined_object_id(self):
+        """
+        Monkey patching object_id property to set to a fixed value. overriding
+        Reassigning Container.object_id is needed for regression testing because
+        object_id is unique to created object rather than to data.
+
+        Parameters
+        ----------
+        self
+
+        Returns
+        -------
+
+        """
+        return "Undefined"
+
+    def __init__(self, input_file, output_file):
+
+        Container.object_id = property(self.undefined_object_id)
+
+        NWBConverter.__init__(self, input_file, output_file)
+
+
 
 
 @pytest.mark.parametrize('NWB_file_inhouse', ['Pvalb-IRES-Cre;Ai14-406663.04.01.01.nwb',
@@ -22,12 +51,12 @@ def test_file_level_regressions(NWB_file_inhouse,tmpdir_factory):
     assert os.path.isfile(nwb1_file_name)
     assert os.path.isfile(test_nwb2_file_name)
 
-    NWBConverter(input_file = nwb1_file_name,
-                 output_file = temp_nwb2_file_name)
+    TestNWBConverter(input_file=nwb1_file_name,
+                     output_file=temp_nwb2_file_name,
+                     )
 
     assert validate_nwb(temp_nwb2_file_name) == []
-
-
+    assert diff_h5(temp_nwb2_file_name,test_nwb2_file_name) == 0
 
 
 


### PR DESCRIPTION
pynwb started using object_id for objects that changes every time file gets created even from the same data. Thus, using h5diff returns a difference when performing regression testing.
Per suggestion from pynwb developer, I added an option to monkey patched object_id property to produce a fixed value for all object ids. This will be used for regression testing.
By default this option will be disabled and allow generating genuine object_ids when converting files.