### PR TITLE
freeze hdmf version to 1.1.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,7 @@ pillow
 argschema
 allensdk
 dictdiffer
+hdmf==1.1.2
 pyabf==2.0.25
 pynwb==1.0.2
 six


### PR DESCRIPTION
nwb related tests were failing after hdmf was upgraded to ver 1.2. Freezing now hdmf to 1.1.2