### PR TITLE
Chirp feature code and off-pipeline analysis tools

### DIFF
--- a/ipfx/bin/run_chirp_feature_collection.py
+++ b/ipfx/bin/run_chirp_feature_collection.py
@@ -1,0 +1,12 @@
+from ipfx.chirp import extract_chirp_features
+import ipfx.offpipeline_utils as op
+import argschema as ags
+
+module = ags.ArgSchemaParser(schema_type=op.FeatureCollectionParameters)
+# TODO: maybe argschema can take care of this logic with a custom field?
+if module.args["input_file"]: 
+    with open(module.args["input_file"], "r") as f:
+        ids = [int(line.strip("\n")) for line in f]
+    op.run_feature_collection(extract_chirp_features, ids=ids, **module.args)
+else:
+    op.run_feature_collection(extract_chirp_features, **module.args)

--- a/ipfx/bin/run_chirp_fv_extraction.py
+++ b/ipfx/bin/run_chirp_fv_extraction.py
@@ -1,0 +1,176 @@
+import numpy as np
+import argschema as ags
+import lims_utils
+import ipfx.chirp as chirp
+from ipfx.aibs_data_set import AibsDataSet
+import logging
+import traceback
+from multiprocessing import Pool
+from functools import partial
+import h5py
+import os
+import json
+import allensdk.core.json_utilities as ju
+from ipfx.stimulus import StimulusOntology
+from ipfx.bin.run_feature_vector_extraction import lims_nwb_information, sdk_nwb_information
+
+class CollectChirpFeatureVectorParameters(ags.ArgSchema):
+    input_file = ags.fields.InputFile(
+        description="input text file with specimen numbers of each line",
+        default=None, allow_none=True)
+    include_failed_cells = ags.fields.Boolean(
+        description="whether to include failed cells",
+        default=False)
+    run_parallel = ags.fields.Boolean(
+        description="whether to use multiprocessing",
+        default=True)
+    output_dir = ags.fields.OutputFile(
+        description="output directory", default=None)
+    output_code = ags.fields.String(
+        description="output code for naming files", default=None)
+    chirp_stimulus_codes = ags.fields.List(ags.fields.String,
+        description="stimulus code for chirps",
+        default=[
+            "C2CHIRP180503",
+            "C2CHIRP171129",
+            "C2CHIRP171103",
+        ],
+        cli_as_single_argument=True)
+    data_source = ags.fields.String(
+        description="Source of NWB files ('sdk' or 'lims')",
+        default="sdk",
+        validate=lambda x: x in ["sdk", "lims"]
+        )
+
+
+def data_for_specimen_id(specimen_id, data_source, chirp_stimulus_codes):
+    logging.debug("specimen_id: {}".format(specimen_id))
+
+    # Manual edit ontology to identify chirp sweeps
+    ontology_data = ju.read(StimulusOntology.DEFAULT_STIMULUS_ONTOLOGY_FILE)
+    mask = []
+    for od in ontology_data:
+        mask_val = True
+        for tagset in od:
+            for c in chirp_stimulus_codes:
+                if c in tagset and "code" in tagset:
+                    mask_val = False
+                    break
+        mask.append(mask_val)
+    ontology_data = [od for od, m in zip(ontology_data, mask) if m is True]
+    ontology_data.append([
+        ["code"] + chirp_stimulus_codes,
+        [
+          "name",
+          "Chirp",
+        ],
+        [
+          "core",
+          "Core 2"
+        ]
+    ])
+
+    ontology = StimulusOntology(ontology_data)
+
+    # Find or retrieve NWB file and ancillary info and construct an AibsDataSet object
+    if data_source == "lims":
+        nwb_path, h5_path = lims_nwb_information(specimen_id)
+        if type(nwb_path) is dict and "error" in nwb_path:
+            logging.warning("Problem getting NWB file for specimen {:d} from LIMS".format(specimen_id))
+            return nwb_path
+
+        try:
+            data_set = AibsDataSet(
+                nwb_file=nwb_path, h5_file=h5_path, ontology=ontology)
+        except Exception as detail:
+            logging.warning("Exception when loading specimen {:d} from LIMS".format(specimen_id))
+            logging.warning(detail)
+            return {"error": {"type": "dataset", "details": traceback.format_exc(limit=None)}}
+    elif data_source == "sdk":
+        nwb_path, sweep_info = sdk_nwb_information(specimen_id)
+        try:
+            data_set = AibsDataSet(
+                nwb_file=nwb_path, sweep_info=sweep_info, ontology=ontology)
+        except Exception as detail:
+            logging.warning("Exception when loading specimen {:d} via Allen SDK".format(specimen_id))
+            logging.warning(detail)
+            return {"error": {"type": "dataset", "details": traceback.format_exc(limit=None)}}
+    else:
+        logging.error("invalid data source specified ({})".format(data_source))
+
+
+    # Identify chirp sweeps
+
+    try:
+        iclamp_st = data_set.filtered_sweep_table(clamp_mode=data_set.CURRENT_CLAMP)
+        iclamp_st = data_set.filtered_sweep_table(clamp_mode=data_set.CURRENT_CLAMP, stimuli=["Chirp"])
+        chirp_sweep_numbers = iclamp_st["sweep_number"].sort_values().values
+    except Exception as detail:
+        logging.warning("Exception when identifying sweeps from specimen {:d}".format(specimen_id))
+        logging.warning(detail)
+        return {"error": {"type": "sweep_table", "details": traceback.format_exc(limit=1)}}
+
+    if len(chirp_sweep_numbers) == 0:
+        logging.info("No chirp sweeps for {:d}".format(specimen_id))
+        return {"error": {"type": "processing", "details:": "no available chirp sweeps"}}
+
+    try:
+        result = chirp.extract_chirp_feature_vector(data_set, chirp_sweep_numbers)
+    except Exception as detail:
+        logging.warning("Exception when processing specimen {:d}".format(specimen_id))
+        logging.warning(detail)
+        return {"error": {"type": "processing", "details": traceback.format_exc(limit=1)}}
+
+    return result
+
+
+def run_chirp_feature_vector_extraction(output_dir, output_code, include_failed_cells,
+        specimen_ids, chirp_stimulus_codes, data_source="lims", run_parallel=True):
+    logging.info("Number of specimens to process: {:d}".format(len(specimen_ids)))
+    get_data_partial = partial(data_for_specimen_id,
+                               data_source=data_source,
+                               chirp_stimulus_codes=chirp_stimulus_codes)
+    if run_parallel:
+        pool = Pool()
+        results = pool.map(get_data_partial, specimen_ids)
+    else:
+        results = map(get_data_partial, specimen_ids)
+    filtered_set = [(i, r) for i, r in zip(specimen_ids, results) if not "error" in r.keys()]
+    error_set = [{"id": i, "error": d} for i, d in zip(specimen_ids, results) if "error" in d.keys()]
+    if len(filtered_set) == 0:
+        logging.info("No specimens had results")
+        return
+
+    used_ids, results = zip(*filtered_set)
+    logging.info("Finished with {:d} processed specimens".format(len(used_ids)))
+    k_sizes = {}
+    for k in results[0].keys():
+        if k not in k_sizes and results[0][k] is not None:
+            k_sizes[k] = len(results[0][k])
+        data = np.array([r[k] if k in r else np.nan * np.zeros(k_sizes[k])
+                        for r in results])
+        if len(data) < len(used_ids):
+            logging.warning("Missing data!")
+            missing = np.array([k not in r for r in results])
+            print(k, np.array(used_ids)[missing])
+        np.save(os.path.join(output_dir, "fv_{:s}_{:s}.npy".format(k, output_code)), data)
+
+    with open(os.path.join(output_dir, "fv_errors_{:s}.json".format(output_code)), "w") as f:
+        json.dump(error_set, f, indent=4)
+
+    np.save(os.path.join(output_dir, "fv_ids_{:s}.npy".format(output_code)), used_ids)
+
+
+def main(output_dir, output_code, input_file, include_failed_cells,
+        run_parallel, data_source, chirp_stimulus_codes, **kwargs):
+    with open(input_file, "r") as f:
+        ids = [int(line.strip("\n")) for line in f]
+
+    run_chirp_feature_vector_extraction(output_dir, output_code,
+        include_failed_cells, chirp_stimulus_codes=chirp_stimulus_codes,
+        specimen_ids=ids, run_parallel=run_parallel, data_source=data_source)
+
+
+if __name__ == "__main__":
+    module = ags.ArgSchemaParser(schema_type=CollectChirpFeatureVectorParameters)
+    main(**module.args)

--- a/ipfx/chirp.py
+++ b/ipfx/chirp.py
@@ -1,0 +1,102 @@
+from __future__ import division
+from __future__ import print_function
+from __future__ import absolute_import
+
+import numpy as np
+import logging
+import pandas as pd
+import scipy.fftpack as fftpack
+
+from . import feature_vectors as fv
+from . import time_series_utils as tsu
+
+
+def extract_chirp_feature_vector(data_set, chirp_sweep_numbers):
+    chirp_sweeps = data_set.sweep_set(chirp_sweep_numbers)
+
+    features = feature_vectors_chirp(chirp_sweeps)
+    return features
+
+
+def feature_vectors_chirp(chirp_sweeps):
+    result = {}
+    amp, phase, freq = chirp_amp_phase(chirp_sweeps)
+    result["chirp"] = np.hstack([amp, phase])
+    return result
+
+
+def chirp_amp_phase(sweep_set, start=0.6, end=20.6, down_rate=2000,
+        min_freq=0.2, max_freq=40.):
+    """ Calculate amplitude and phase of chirp responses
+
+    Parameters
+    ----------
+    sweep_set: SweepSet
+        Set of chirp sweeps
+    start: float (optional, default 0.6)
+        Start of chirp stimulus in seconds
+    end: float (optional, default 20.6)
+        End of chirp stimulus in seconds
+    down_rate: int (optional, default 2000)
+        Sampling rate for downsampling before FFT
+    min_freq: float (optional, default 0.2)
+        Minimum frequency for output to contain
+    max_freq: float (optional, default 40)
+        Maximum frequency for output to contain
+
+    Returns
+    -------
+    amplitude: array
+        Aka resistance
+    phase: array
+        Aka reactance
+    """
+    v_list = []
+    i_list = []
+    for swp in sweep_set.sweeps:
+        # check for truncated sweep
+        if np.all(swp.v[-100:] == 0):
+            continue
+        v_list.append(swp.v)
+        i_list.append(swp.i)
+
+
+    avg_v = np.vstack(v_list).mean(axis=0)
+    avg_i = np.vstack(i_list).mean(axis=0)
+    t = sweep_set.sweeps[0].t
+
+    current_rate = np.rint(1 / (t[1] - t[0]))
+    if current_rate > down_rate:
+        width = int(current_rate / down_rate)
+        ds_v = ds_v = fv.subsample_average(avg_v, width)
+        ds_i = fv.subsample_average(avg_i, width)
+        ds_t = t[::width]
+    else:
+        ds_v = avg_v
+        ds_i = avg_i
+        ds_t = t
+
+    start_index = tsu.find_time_index(ds_t, start)
+    end_index = tsu.find_time_index(ds_t, end)
+
+    N = len(ds_v[start_index:end_index])
+    T = ds_t[1] - ds_t[0]
+    xf = np.linspace(0.0, 1.0/(2.0*T), N//2)
+
+    v_fft = fftpack.fft(ds_v[start_index:end_index])
+    i_fft = fftpack.fft(ds_i[start_index:end_index])
+    Z = v_fft / i_fft
+    R = np.real(Z)
+    X = np.imag(Z)
+
+    resistance = np.abs(Z)[0:N//2]
+    reactance = np.arctan(X / R)[0:N//2]
+
+    low_ind = tsu.find_time_index(xf, min_freq)
+    high_ind = tsu.find_time_index(xf, max_freq)
+
+    return resistance[low_ind:high_ind], reactance[low_ind:high_ind], xf[low_ind:high_ind]
+
+
+
+

--- a/ipfx/chirp.py
+++ b/ipfx/chirp.py
@@ -70,8 +70,8 @@ def chirp_amp_phase(sweep_set, start=0.6, end=20.6, down_rate=2000,
     current_rate = np.rint(1 / (t[1] - t[0]))
     if current_rate > down_rate:
         width = int(current_rate / down_rate)
-        ds_v = ds_v = fv.subsample_average(avg_v, width)
-        ds_i = fv.subsample_average(avg_i, width)
+        ds_v = ds_v = fv._subsample_average(avg_v, width)
+        ds_i = fv._subsample_average(avg_i, width)
         ds_t = t[::width]
     else:
         ds_v = avg_v

--- a/ipfx/chirp.py
+++ b/ipfx/chirp.py
@@ -7,25 +7,83 @@ import logging
 import pandas as pd
 import scipy.fftpack as fftpack
 
+from . import offpipeline_utils as op
 from . import feature_vectors as fv
 from . import time_series_utils as tsu
 
+CHIRP_CODES = [
+            "C2CHIRP180503",
+            "C2CHIRP171129",
+            "C2CHIRP171103",
+        ]
+
+def extract_chirp_features(specimen_id, data_source='lims', sweep_qc_option='none', **kwargs):
+    dataset = op.dataset_for_specimen_id(specimen_id, data_source=data_source, ontology=ontology_with_chirps())
+    sweepset = op.sweepset_by_type_qc(dataset, specimen_id, stimuli_names=["Chirp"])
+    results = []
+    if len(sweepset.sweeps)==0:
+        return {}
+    for sweep in sweepset.sweeps:
+        results.append(chirp_sweep_features(sweep, **kwargs))
+    mean_results = {key: np.mean([res[key] for res in results]) for key in results[0]}
+    return mean_results
+
+def chirp_sweep_features(sweep, **kwargs):
+    v, i, freq = transform_sweep(sweep, **kwargs)
+    Z = v / i
+    amp = np.abs(Z)
+    phase = np.angle(Z)
+
+    from scipy.signal import savgol_filter
+    # pick odd number, approx number of points for 2 Hz interval
+    n_filt = int(np.rint(1/(freq[1]-freq[0])))*2 + 1
+    filt = lambda x: savgol_filter(x, n_filt, 5)
+    amp, phase = map(filt, [amp, phase])
+
+    imax = np.argmax(amp)
+    features = {
+        "z_low": amp[0],
+        "z_high": amp[-1],
+        "z_max": amp[imax],
+        "peak_ratio": amp[imax]/amp[0],
+        "peak_freq": freq[imax],
+        "phase_max": np.max(phase),
+        "phase_low": phase[0],
+        "phase_high": phase[-1]
+    }
+    return features
 
 def extract_chirp_feature_vector(data_set, chirp_sweep_numbers):
     chirp_sweeps = data_set.sweep_set(chirp_sweep_numbers)
-
-    features = feature_vectors_chirp(chirp_sweeps)
-    return features
-
-
-def feature_vectors_chirp(chirp_sweeps):
     result = {}
     amp, phase, freq = chirp_amp_phase(chirp_sweeps)
     result["chirp"] = np.hstack([amp, phase])
-    return result
+    return features
 
 
-def chirp_amp_phase(sweep_set, start=0.6, end=20.6, down_rate=2000,
+def averaged_chirp_transform(sweep_set, df=0.1, n_sample=10000):
+    """ Calculate averaged amplitude and phase of chirp responses,
+    averaging results after transform.
+    """
+    amp_list = []
+    phase_list = []
+    for sweep in sweep_set.sweeps:
+        v, i, freq = transform_sweep(sweep, n_sample=n_sample)
+        Z = v / i
+        amp = np.abs(Z)
+        phase = np.angle(Z)
+        
+        width = int(np.rint(df/(freq[1]-freq[0])))
+        amp = fv._subsample_average(amp, width)
+        phase = fv._subsample_average(phase, width)
+        amp_list.append(amp)
+        phase_list.append(phase)
+
+    avg_amp = np.vstack(amp_list).mean(axis=0)
+    avg_phase = np.vstack(phase_list).mean(axis=0)
+    return avg_amp, avg_phase, freq
+
+def chirp_amp_phase(t, v, i, start=0.6, end=20.6, down_rate=2000,
         min_freq=0.2, max_freq=40.):
     """ Calculate amplitude and phase of chirp responses
 
@@ -100,5 +158,60 @@ def chirp_amp_phase(sweep_set, start=0.6, end=20.6, down_rate=2000,
     return resistance[low_ind:high_ind], reactance[low_ind:high_ind], xf[low_ind:high_ind]
 
 
+def transform_sweep(sweep, n_sample=10000, min_freq=1., max_freq=35.):
+    sweep.select_epoch("stim")
+    v = sweep.v
+    i = sweep.i
+    t = sweep.t
+    N = len(v)
+
+    # down_rate=2000
+    # width = int(sweep.sampling_rate / down_rate)
+
+    width = int(N / n_sample)
+    pad = int(width*np.ceil(N/width) - N)
+    v = fv._subsample_average(np.pad(v, (pad,0), 'constant', constant_values=np.nan), width)
+    i = fv._subsample_average(np.pad(i, (pad,0), 'constant', constant_values=np.nan), width)
+    t = t[::width]
+
+    N = len(v)
+    dt = t[1] - t[0]
+    xf = np.linspace(0.0, 1.0/(2.0*dt), N//2)
+
+    v_fft = fftpack.fft(v)
+    i_fft = fftpack.fft(i)
+
+    low_ind = tsu.find_time_index(xf, min_freq)
+    high_ind = tsu.find_time_index(xf, max_freq)
+
+    return v_fft[low_ind:high_ind], i_fft[low_ind:high_ind], xf[low_ind:high_ind]
 
 
+import json
+import allensdk.core.json_utilities as ju
+from ipfx.stimulus import StimulusOntology
+def ontology_with_chirps(chirp_stimulus_codes=CHIRP_CODES):
+# Manual edit ontology to identify chirp sweeps
+    ontology_data = ju.read(StimulusOntology.DEFAULT_STIMULUS_ONTOLOGY_FILE)
+    mask = []
+    for od in ontology_data:
+        mask_val = True
+        for tagset in od:
+            for c in chirp_stimulus_codes:
+                if c in tagset and "code" in tagset:
+                    mask_val = False
+                    break
+        mask.append(mask_val)
+    ontology_data = [od for od, m in zip(ontology_data, mask) if m is True]
+    ontology_data.append([
+        ["code"] + chirp_stimulus_codes,
+        [
+          "name",
+          "Chirp",
+        ],
+        [
+          "core",
+          "Core 2"
+        ]
+    ])
+    return StimulusOntology(ontology_data)

--- a/ipfx/chirp.py
+++ b/ipfx/chirp.py
@@ -82,7 +82,7 @@ def extract_chirp_feature_vector(data_set, chirp_sweep_numbers):
     return features
 
 
-def chirp_amp_phase(t, v, i, start=0.6, end=20.6, down_rate=2000,
+def chirp_amp_phase(sweep_set, start=0.6, end=20.6, down_rate=2000,
         min_freq=0.2, max_freq=40.):
     """ Calculate amplitude and phase of chirp responses
 

--- a/ipfx/chirp.py
+++ b/ipfx/chirp.py
@@ -50,6 +50,8 @@ def chirp_amp_phase(sweep_set, start=0.6, end=20.6, down_rate=2000,
         Aka resistance
     phase: array
         Aka reactance
+    freq: array
+        Frequencies for amplitude and phase results
     """
     v_list = []
     i_list = []

--- a/ipfx/offpipeline_utils.py
+++ b/ipfx/offpipeline_utils.py
@@ -1,0 +1,152 @@
+import numpy as np
+import pandas as pd
+import logging
+import traceback
+from functools import partial
+from multiprocessing import Pool
+import allensdk.core.json_utilities as ju
+from ipfx.stimulus import StimulusOntology
+from ipfx.aibs_data_set import AibsDataSet
+from ipfx.bin.run_feature_vector_extraction import lims_nwb_information, sdk_nwb_information
+
+def dataset_for_specimen_id(specimen_id, data_source="lims", ontology=None):
+    """Construct an AibsDataSet for a cell by specimen_id
+    
+    Parameters
+    ----------
+    specimen_id : int or str
+    data_source : str, optional
+        "lims" or "sdk", by default "lims"
+    ontology : StimulusOntology, optional
+    
+    Returns
+    -------
+    AibsDataSet
+    """
+    ontology = ontology or StimulusOntology(ju.read(StimulusOntology.DEFAULT_STIMULUS_ONTOLOGY_FILE))
+    logging.debug("specimen_id: {}".format(specimen_id))
+    # Find or retrieve NWB file and ancillary info and construct an AibsDataSet object
+    if data_source == "lims":
+        nwb_path, h5_path = lims_nwb_information(specimen_id)
+        if type(nwb_path) is dict and "error" in nwb_path:
+            error_dict = nwb_path
+            logging.warning("Problem getting NWB file for specimen {:d} from LIMS".format(specimen_id))
+            return error_dict
+
+        try:
+            dataset = AibsDataSet(
+                nwb_file=nwb_path, h5_file=h5_path, ontology=ontology)
+        except Exception as detail:
+            logging.warning("Exception when loading specimen {:d} from LIMS".format(specimen_id))
+            logging.warning(detail)
+            return {"error": {"type": "dataset", "details": traceback.format_exc(limit=None)}}
+    elif data_source == "sdk":
+        nwb_path, sweep_info = sdk_nwb_information(specimen_id)
+        try:
+            dataset = AibsDataSet(
+                nwb_file=nwb_path, sweep_info=sweep_info, ontology=ontology)
+        except Exception as detail:
+            logging.warning("Exception when loading specimen {:d} via Allen SDK".format(specimen_id))
+            logging.warning(detail)
+            return {"error": {"type": "dataset", "details": traceback.format_exc(limit=None)}}
+    else:
+        logging.error("invalid data source specified ({})".format(data_source))
+
+    return dataset
+
+def sweepset_by_type_qc(dataset, specimen_id, stimuli_names=None, sweep_qc_option="none"):
+    sweep_numbers = sweep_numbers_by_type_qc(dataset, specimen_id, 
+                        stimuli_names=stimuli_names, sweep_qc_option=sweep_qc_option)
+    return dataset.sweep_set(sweep_numbers)
+
+def sweep_numbers_by_type_qc(dataset, specimen_id, stimuli_names=None, sweep_qc_option="none"):
+    exist_sql = """
+        select swp.sweep_number from ephys_sweeps swp
+        where swp.specimen_id = :1
+        and swp.sweep_number = any(:2)
+    """
+
+    passed_sql = """
+        select swp.sweep_number from ephys_sweeps swp
+        where swp.specimen_id = :1
+        and swp.sweep_number = any(:2)
+        and swp.workflow_state like '%%passed'
+    """
+
+    passed_except_delta_vm_sql = """
+        select swp.sweep_number, tag.name
+        from ephys_sweeps swp
+        join ephys_sweep_tags_ephys_sweeps estes on estes.ephys_sweep_id = swp.id
+        join ephys_sweep_tags tag on tag.id = estes.ephys_sweep_tag_id
+        where swp.specimen_id = :1
+        and swp.sweep_number = any(:2)
+    """
+
+    iclamp_st = dataset.filtered_sweep_table(clamp_mode=dataset.CURRENT_CLAMP, stimuli=stimuli_names)
+
+    if sweep_qc_option == "none":
+        return iclamp_st["sweep_number"].sort_values().values
+    else:
+        # check that sweeps exist in LIMS
+        sweep_num_list = iclamp_st["sweep_number"].sort_values().tolist()
+        results = lq.query(exist_sql, (specimen_id, sweep_num_list))
+        res_nums = pd.DataFrame(results, columns=["sweep_number"])["sweep_number"].tolist()
+
+        not_checked_list = []
+        for swp_num in sweep_num_list:
+            if swp_num not in res_nums:
+                logging.debug("Could not find sweep {:d} from specimen {:d} in LIMS for QC check".format(swp_num, specimen_id))
+                not_checked_list.append(swp_num)
+
+        # get straight-up passed sweeps
+        results = lq.query(passed_sql, (specimen_id, sweep_num_list))
+        results_df = pd.DataFrame(results, columns=["sweep_number"])
+        passed_sweep_nums = results_df["sweep_number"].values
+
+        if sweep_qc_option == "lims-passed-only":
+            return np.sort(np.hstack([passed_sweep_nums, np.array(not_checked_list)])) # deciding to keep non-checked sweeps for now
+        elif sweep_qc_option == "lims-passed-except-delta-vm":
+
+            # also get sweeps that only fail due to delta Vm
+            failed_sweep_list = list(set(sweep_num_list) - set(passed_sweep_nums))
+            if len(failed_sweep_list) == 0:
+                return np.sort(passed_sweep_nums)
+            results = lq.query(passed_except_delta_vm_sql, (specimen_id, failed_sweep_list))
+            results_df = pd.DataFrame(results, columns=["sweep_number", "name"])
+
+            # not all cells have tagged QC status - if there are no tags assume the
+            # fail call is correct and exclude those sweeps
+            tagged_mask = np.array([sn in results_df["sweep_number"].tolist() for sn in failed_sweep_list])
+
+            # otherwise, check for having an error tag that isn't 'Vm delta'
+            # and exclude those sweeps
+            has_non_delta_tags = np.array([np.any((results_df["sweep_number"].values == sn) &
+                (results_df["name"].values != "Vm delta")) for sn in failed_sweep_list])
+
+            also_passing_nums = np.array(failed_sweep_list)[tagged_mask & ~has_non_delta_tags]
+
+            return np.sort(np.hstack([passed_sweep_nums, also_passing_nums, np.array(not_checked_list)]))
+        else:
+            raise ValueError("Invalid sweep-level QC option {}".format(sweep_qc_option))
+
+def run_feature_collection(feature_fcn, ids=None, project="T301", sweep_qc_option='none', include_failed_cells=False,
+        output_file=None, n_procs=0, **kwargs):
+    if ids is not None:
+        specimen_ids = ids
+    else:
+        specimen_ids = lq.project_specimen_ids(project, passed_only=not include_failed_cells)
+
+    logging.info("Number of specimens to process: {:d}".format(len(specimen_ids)))
+
+    get_data_partial = partial(feature_fcn, sweep_qc_option=sweep_qc_option, **kwargs)
+
+    if n_procs:
+        pool = Pool(n_procs)
+        results = pool.map(get_data_partial, specimen_ids)
+    else:
+        results = map(get_data_partial, specimen_ids)
+
+    df = pd.DataFrame.from_records(results, index=specimen_ids)
+    if output_file:
+        df.to_csv(output_file)
+    return df

--- a/ipfx/offpipeline_utils.py
+++ b/ipfx/offpipeline_utils.py
@@ -5,48 +5,102 @@ import traceback
 from functools import partial
 from multiprocessing import Pool
 import allensdk.core.json_utilities as ju
+import ipfx.bin.lims_queries as lq
 from ipfx.stimulus import StimulusOntology
 from ipfx.aibs_data_set import AibsDataSet
 from ipfx.bin.run_feature_vector_extraction import lims_nwb_information, sdk_nwb_information
+import argschema as ags
+
+
+class FeatureCollectionParameters(ags.ArgSchema):
+    ids = ags.fields.List( ags.fields.Integer,
+        description="List of specimen IDs to process",
+        cli_as_single_argument=True,
+        default=None, allow_none=True
+    )
+    input_file = ags.fields.InputFile(
+        description=("Input file of specimen IDs (one per line)"
+                     "- optional if LIMS is source"),
+        default=None, allow_none=True)
+    project = ags.fields.String(
+        description="Project code used for LIMS query, e.g. hIVSCC-MET",
+        default=None,
+        allow_none=True
+    )
+    cell_count_limit = ags.fields.Number(
+        description="Limit to number of cells evaluated",
+        default=float('inf')
+    )
+    sweep_qc_option = ags.fields.String(
+        description=("Sweep-level QC option - "
+                     "'none': use all sweeps; "
+                     "'lims-passed-only': check passed status with LIMS and "
+                     "only used passed sweeps "
+                     "'lims-passed-except-delta-vm': check status with LIMS and "
+                     "use passed sweeps and sweeps where only failure criterion is delta_vm"
+                     ),
+        default='none'
+    )
+    include_failed_cells = ags.fields.Boolean(
+        description="whether to include failed cells",
+        default=False)
+    run_parallel = ags.fields.Boolean(
+        description="whether to use multiprocessing",
+        default=False)
+    output_file = ags.fields.OutputFile(
+        description="output file path",
+        default=None,
+        allow_none=True)
+    data_source = ags.fields.String(
+        description="Source of NWB files ('sdk' or 'lims')",
+        default="lims",
+        validate=lambda x: x in ["sdk", "lims"]
+    )
+
 
 def dataset_for_specimen_id(specimen_id, data_source="lims", ontology=None):
     """Construct an AibsDataSet for a cell by specimen_id
-    
+
     Parameters
     ----------
     specimen_id : int or str
     data_source : str, optional
         "lims" or "sdk", by default "lims"
     ontology : StimulusOntology, optional
-    
+
     Returns
     -------
     AibsDataSet
     """
-    ontology = ontology or StimulusOntology(ju.read(StimulusOntology.DEFAULT_STIMULUS_ONTOLOGY_FILE))
+    ontology = ontology or StimulusOntology(
+        ju.read(StimulusOntology.DEFAULT_STIMULUS_ONTOLOGY_FILE))
     logging.debug("specimen_id: {}".format(specimen_id))
     # Find or retrieve NWB file and ancillary info and construct an AibsDataSet object
     if data_source == "lims":
         nwb_path, h5_path = lims_nwb_information(specimen_id)
         if type(nwb_path) is dict and "error" in nwb_path:
             error_dict = nwb_path
-            raise IOError("Problem getting NWB file for specimen {:d} from LIMS".format(specimen_id))
+            raise IOError(
+                "Problem getting NWB file for specimen {:d} from LIMS".format(specimen_id))
 
         dataset = AibsDataSet(
-                nwb_file=nwb_path, h5_file=h5_path, ontology=ontology)
+            nwb_file=nwb_path, h5_file=h5_path, ontology=ontology)
     elif data_source == "sdk":
         nwb_path, sweep_info = sdk_nwb_information(specimen_id)
         dataset = AibsDataSet(
-                nwb_file=nwb_path, sweep_info=sweep_info, ontology=ontology)
+            nwb_file=nwb_path, sweep_info=sweep_info, ontology=ontology)
     else:
-        raise ValueError("invalid data source specified ({})".format(data_source))
+        raise ValueError(
+            "invalid data source specified ({})".format(data_source))
 
     return dataset
 
+
 def sweepset_by_type_qc(dataset, specimen_id, stimuli_names=None, sweep_qc_option="none"):
-    sweep_numbers = sweep_numbers_by_type_qc(dataset, specimen_id, 
-                        stimuli_names=stimuli_names, sweep_qc_option=sweep_qc_option)
+    sweep_numbers = sweep_numbers_by_type_qc(dataset, specimen_id,
+                                             stimuli_names=stimuli_names, sweep_qc_option=sweep_qc_option)
     return dataset.sweep_set(sweep_numbers)
+
 
 def sweep_numbers_by_type_qc(dataset, specimen_id, stimuli_names=None, sweep_qc_option="none"):
     exist_sql = """
@@ -71,7 +125,8 @@ def sweep_numbers_by_type_qc(dataset, specimen_id, stimuli_names=None, sweep_qc_
         and swp.sweep_number = any(:2)
     """
 
-    iclamp_st = dataset.filtered_sweep_table(clamp_mode=dataset.CURRENT_CLAMP, stimuli=stimuli_names)
+    iclamp_st = dataset.filtered_sweep_table(
+        clamp_mode=dataset.CURRENT_CLAMP, stimuli=stimuli_names)
 
     if sweep_qc_option == "none":
         return iclamp_st["sweep_number"].sort_values().values
@@ -79,12 +134,14 @@ def sweep_numbers_by_type_qc(dataset, specimen_id, stimuli_names=None, sweep_qc_
         # check that sweeps exist in LIMS
         sweep_num_list = iclamp_st["sweep_number"].sort_values().tolist()
         results = lq.query(exist_sql, (specimen_id, sweep_num_list))
-        res_nums = pd.DataFrame(results, columns=["sweep_number"])["sweep_number"].tolist()
+        res_nums = pd.DataFrame(results, columns=["sweep_number"])[
+            "sweep_number"].tolist()
 
         not_checked_list = []
         for swp_num in sweep_num_list:
             if swp_num not in res_nums:
-                logging.debug("Could not find sweep {:d} from specimen {:d} in LIMS for QC check".format(swp_num, specimen_id))
+                logging.debug("Could not find sweep {:d} from specimen {:d} in LIMS for QC check".format(
+                    swp_num, specimen_id))
                 not_checked_list.append(swp_num)
 
         # get straight-up passed sweeps
@@ -93,44 +150,56 @@ def sweep_numbers_by_type_qc(dataset, specimen_id, stimuli_names=None, sweep_qc_
         passed_sweep_nums = results_df["sweep_number"].values
 
         if sweep_qc_option == "lims-passed-only":
-            return np.sort(np.hstack([passed_sweep_nums, np.array(not_checked_list)])) # deciding to keep non-checked sweeps for now
+            # deciding to keep non-checked sweeps for now
+            return np.sort(np.hstack([passed_sweep_nums, np.array(not_checked_list)]))
         elif sweep_qc_option == "lims-passed-except-delta-vm":
 
             # also get sweeps that only fail due to delta Vm
-            failed_sweep_list = list(set(sweep_num_list) - set(passed_sweep_nums))
+            failed_sweep_list = list(
+                set(sweep_num_list) - set(passed_sweep_nums))
             if len(failed_sweep_list) == 0:
                 return np.sort(passed_sweep_nums)
-            results = lq.query(passed_except_delta_vm_sql, (specimen_id, failed_sweep_list))
-            results_df = pd.DataFrame(results, columns=["sweep_number", "name"])
+            results = lq.query(passed_except_delta_vm_sql,
+                               (specimen_id, failed_sweep_list))
+            results_df = pd.DataFrame(
+                results, columns=["sweep_number", "name"])
 
             # not all cells have tagged QC status - if there are no tags assume the
             # fail call is correct and exclude those sweeps
-            tagged_mask = np.array([sn in results_df["sweep_number"].tolist() for sn in failed_sweep_list])
+            tagged_mask = np.array(
+                [sn in results_df["sweep_number"].tolist() for sn in failed_sweep_list])
 
             # otherwise, check for having an error tag that isn't 'Vm delta'
             # and exclude those sweeps
             has_non_delta_tags = np.array([np.any((results_df["sweep_number"].values == sn) &
-                (results_df["name"].values != "Vm delta")) for sn in failed_sweep_list])
+                                                  (results_df["name"].values != "Vm delta")) for sn in failed_sweep_list])
 
-            also_passing_nums = np.array(failed_sweep_list)[tagged_mask & ~has_non_delta_tags]
+            also_passing_nums = np.array(failed_sweep_list)[
+                tagged_mask & ~has_non_delta_tags]
 
             return np.sort(np.hstack([passed_sweep_nums, also_passing_nums, np.array(not_checked_list)]))
         else:
-            raise ValueError("Invalid sweep-level QC option {}".format(sweep_qc_option))
+            raise ValueError(
+                "Invalid sweep-level QC option {}".format(sweep_qc_option))
+
 
 def run_feature_collection(feature_fcn, ids=None, project="T301", sweep_qc_option='none', include_failed_cells=False,
-        output_file=None, n_procs=0, **kwargs):
+                           output_file=None, run_parallel=False, data_source='lims', cell_count_limit=float('inf'), **kwargs):
     if ids is not None:
         specimen_ids = ids
     else:
-        specimen_ids = lq.project_specimen_ids(project, passed_only=not include_failed_cells)
+        specimen_ids = lq.project_specimen_ids(
+            project, passed_only=not include_failed_cells)
+    if len(specimen_ids) > cell_count_limit:
+        specimen_ids = specimen_ids[:cell_count_limit]
+    logging.info(
+        "Number of specimens to process: {:d}".format(len(specimen_ids)))
 
-    logging.info("Number of specimens to process: {:d}".format(len(specimen_ids)))
+    get_data_partial = partial(
+        feature_fcn, sweep_qc_option=sweep_qc_option, data_source=data_source)
 
-    get_data_partial = partial(feature_fcn, sweep_qc_option=sweep_qc_option, **kwargs)
-
-    if n_procs:
-        pool = Pool(n_procs)
+    if run_parallel:
+        pool = Pool()
         results = pool.map(get_data_partial, specimen_ids)
     else:
         results = map(get_data_partial, specimen_ids)

--- a/ipfx/offpipeline_utils.py
+++ b/ipfx/offpipeline_utils.py
@@ -30,27 +30,16 @@ def dataset_for_specimen_id(specimen_id, data_source="lims", ontology=None):
         nwb_path, h5_path = lims_nwb_information(specimen_id)
         if type(nwb_path) is dict and "error" in nwb_path:
             error_dict = nwb_path
-            logging.warning("Problem getting NWB file for specimen {:d} from LIMS".format(specimen_id))
-            return error_dict
+            raise IOError("Problem getting NWB file for specimen {:d} from LIMS".format(specimen_id))
 
-        try:
-            dataset = AibsDataSet(
+        dataset = AibsDataSet(
                 nwb_file=nwb_path, h5_file=h5_path, ontology=ontology)
-        except Exception as detail:
-            logging.warning("Exception when loading specimen {:d} from LIMS".format(specimen_id))
-            logging.warning(detail)
-            return {"error": {"type": "dataset", "details": traceback.format_exc(limit=None)}}
     elif data_source == "sdk":
         nwb_path, sweep_info = sdk_nwb_information(specimen_id)
-        try:
-            dataset = AibsDataSet(
+        dataset = AibsDataSet(
                 nwb_file=nwb_path, sweep_info=sweep_info, ontology=ontology)
-        except Exception as detail:
-            logging.warning("Exception when loading specimen {:d} via Allen SDK".format(specimen_id))
-            logging.warning(detail)
-            return {"error": {"type": "dataset", "details": traceback.format_exc(limit=None)}}
     else:
-        logging.error("invalid data source specified ({})".format(data_source))
+        raise ValueError("invalid data source specified ({})".format(data_source))
 
     return dataset
 

--- a/tests/test_chirp.py
+++ b/tests/test_chirp.py
@@ -1,0 +1,75 @@
+import numpy as np
+import scipy
+import ipfx.chirp as chirp
+from ipfx.sweep import Sweep, SweepSet
+
+
+def test_chirp_output():
+    # Stuff for sweep construction
+    sampling_rate = 2000
+    t = np.arange(0, 20 * sampling_rate) * (1 / sampling_rate)
+    clamp_mode = "CurrentClamp"
+    epochs = {"sweep": (0, len(t) - 1),
+        "test": None,
+        "recording": None,
+        "experiment": None,
+        "stim": None}
+
+    base_chirp = scipy.signal.chirp(t, 0.5, 20, 40, method="linear")
+    i = base_chirp
+
+    # linear descreasing profile
+    profile = np.linspace(1., 0.5, num=len(t))
+    v = base_chirp * profile
+    test_sweep = Sweep(t, v, i, clamp_mode, sampling_rate, epochs=epochs)
+    sweep_set = SweepSet([test_sweep])
+
+    amp, phase, freq = chirp.chirp_amp_phase(sweep_set, start=0, end=19.9)
+
+    # Confirm goes from 1 to 0.5
+    tol = 0.1
+    assert np.abs(amp[0] - 1) < tol
+    assert np.abs(amp[-1] - 0.5) < tol
+
+    # "resonant" profile
+    profile = (-(t - 10) ** 2 + 100) / 100 + 1
+    v = base_chirp * profile
+    test_sweep = Sweep(t, v, i, clamp_mode, sampling_rate, epochs=epochs)
+    sweep_set = SweepSet([test_sweep])
+
+    amp, phase, freq = chirp.chirp_amp_phase(sweep_set, start=0, end=19.9)
+
+    # Confirm it peaks around 2 near 20 Hz
+    amp_tol = 0.1
+    freq_tol = 1
+
+    assert np.abs(np.max(amp) - 2) < amp_tol
+    assert np.abs(freq[np.argmax(amp)] - 20) < freq_tol
+
+
+def test_chirp_downsample():
+    # Stuff for sweep construction
+    sampling_rate = 2000
+    t = np.arange(0, 20 * sampling_rate) * (1 / sampling_rate)
+    clamp_mode = "CurrentClamp"
+    epochs = {"sweep": (0, len(t) - 1),
+        "test": None,
+        "recording": None,
+        "experiment": None,
+        "stim": None}
+
+    base_chirp = scipy.signal.chirp(t, 0.5, 20, 40, method="linear")
+    i = base_chirp
+
+    # linear descreasing profile
+    profile = np.linspace(1., 0.5, num=len(t))
+    v = base_chirp * profile
+    test_sweep = Sweep(t, v, i, clamp_mode, sampling_rate, epochs=epochs)
+    sweep_set = SweepSet([test_sweep])
+
+    amp, phase, freq = chirp.chirp_amp_phase(sweep_set, start=0, end=19.9, down_rate=sampling_rate/2)
+
+    # Confirm goes from 1 to 0.5
+    tol = 0.1
+    assert np.abs(amp[0] - 1) < tol
+    assert np.abs(amp[-1] - 0.5) < tol


### PR DESCRIPTION
This is a bit of an update to Nathan's chirp code:

- actual chirp features (peak frequency, etc.) in addition to Nathan's feature vectors
- transforming single chirp sweeps not just averaged sweeps
- an initial foray into providing some tools for running feature analysis in an off-pipeline context. duplicates some functionality in run_feature_collection, run_feature_vector_extraction, etc but in a more modular form that can be used across different use cases.

@gouwens , in this version I've left your code functionally unchanged, but one point that should be resolved is how to deal with sweeps of different duration (different stimulus codes). Right now you're windowing and averaging before transform, but I'd suggest the appropriate approach is either to restrict to only the final chirp sweep type (other two seem to have been used in early cells to explore parameters), or to average FVs after transform. I could easily link into my code to do this if you want.