### PR TITLE
Hide deprecation warning from pynwb

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -3,3 +3,6 @@
 markers =
     slow: slow tests
     requires_lims: require connection to LIMS
+
+filterwarnings =
+    ignore:add_child is deprecated. Set the parent attribute instead.:DeprecationWarning


### PR DESCRIPTION
hide hdmf's warning 'add child is depcreated' when adding
device and electrode to the nwbfile

Resolve 276