### PR TITLE
Make abf conversion work on linux

### DIFF
--- a/ipfx/x_to_nwb/ABFConverter.py
+++ b/ipfx/x_to_nwb/ABFConverter.py
@@ -534,7 +534,6 @@ class ABFConverter:
 
         for file_index, abf in enumerate(self.abfs):
 
-            starting_time = self._calculateStartingTime(abf)
             stimulus_description = ABFConverter._getProtocolName(abf.protocol)
             _, jsonSource = self._findSettingsEntry(abf)
             log.debug(f"Using JSON settings for {jsonSource}.")
@@ -558,6 +557,7 @@ class ABFConverter:
                     electrode = electrodes[channel]
                     gain = abf._adcSection.fADCProgrammableGain[channel]
                     resolution = np.nan
+                    starting_time = self._calculateStartingTime(abf)
                     rate = float(abf.dataRate)
                     description = json.dumps({"cycle_id": cycle_id,
                                               "protocol": abf.protocol,

--- a/ipfx/x_to_nwb/ABFConverter.py
+++ b/ipfx/x_to_nwb/ABFConverter.py
@@ -57,10 +57,8 @@ class ABFConverter:
 
         self.abfs = []
 
-        pyabf.stimulus.Stimulus.protocolStorageDir = ABFConverter.protocolStorageDir
-
         for inFile in inFiles:
-            abf = pyabf.ABF(inFile, loadData=False)
+            abf = pyabf.ABF(inFile, loadData=False, stimulusFileFolder=ABFConverter.protocolStorageDir)
             self.abfs.append(abf)
 
             # ensure that the input file matches our expectations
@@ -97,7 +95,7 @@ class ABFConverter:
         root, ext = os.path.splitext(inFile)
 
         abf = pyabf.ABF(inFile)
-        abf.getInfoPage().generateHTML(saveAs=root + ".html")
+        pyabf.abfHeaderDisplay.abfInfoPage(abf).generateHTML(saveAs=root + ".html")
 
     @staticmethod
     def _getProtocolName(protocolName):

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ argschema
 allensdk
 dictdiffer
 hdmf==1.1.2
-pyabf==2.0.25
+pyabf==2.2.0
 pynwb==1.0.2
 six
 watchdog

--- a/tests/test_x_nwb.py
+++ b/tests/test_x_nwb.py
@@ -27,10 +27,6 @@ from .helpers_for_tests import diff_h5
 pytestmark = pytest.mark.xnwbtest
 
 
-pytest.skip("All x-nwb tests fail",
-            allow_module_level=True)
-
-
 def get_raw_files():
 
     # we have to do that here as we need to have the files


### PR DESCRIPTION
So this now makes the ABF conversion work on Linux as well. While doing that I also found a bug with the starting_time.

I also reenabled the X-NWB tests as they are the only way to find these kind of errors.

Requires a yet-to-be-released pyABF version, see https://github.com/swharden/pyABF/pull/97 for the PR.

While doing that I also fixed https://github.com/swharden/pyABF/pull/94 but that is unrelated to our use.

Close #282.