### PR TITLE
Switch to getting NWBIgor files from LIMS

### DIFF
--- a/ipfx/lims_queries.py
+++ b/ipfx/lims_queries.py
@@ -142,15 +142,25 @@ def get_specimen_info_from_lims_by_id(specimen_id):
 def get_nwb_path_from_lims(ephys_roi_result):
 
     # well known file type ID for NWB files is 475137571
+    # well known file type ID for NWBIgor files is 570280085
 
+    # Try to find NWBIgor file preferentially
     result = query("""
     SELECT f.filename, f.storage_directory FROM well_known_files f
-    WHERE f.attachable_type = 'EphysRoiResult' AND f.attachable_id = %s AND f.well_known_file_type_id = 475137571
+    WHERE f.attachable_type = 'EphysRoiResult' AND f.attachable_id = %s AND f.well_known_file_type_id = 570280085
     """ % (ephys_roi_result,))
 
     if len(result) == 0:
-        logging.info("No result from query to find NWB file")
-        return None
+        # Fall back to looking for NWB type
+
+        result = query("""
+        SELECT f.filename, f.storage_directory FROM well_known_files f
+        WHERE f.attachable_type = 'EphysRoiResult' AND f.attachable_id = %s AND f.well_known_file_type_id = 475137571
+        """ % (ephys_roi_result,))
+
+        if len(result) == 0:
+            logging.info("No result from query to find NWB file")
+            return None
 
     result = result[0]
     if result:

--- a/ipfx/lims_queries.py
+++ b/ipfx/lims_queries.py
@@ -140,29 +140,39 @@ def get_specimen_info_from_lims_by_id(specimen_id):
 
 
 def get_nwb_path_from_lims(ephys_roi_result):
+    """
+    Try to find NWBIgor file preferentially
+    If not found, look for a processed NWB file
 
-    # well known file type ID for NWB files is 475137571
-    # well known file type ID for NWBIgor files is 570280085
+    well known file type ID for NWB files is 475137571
+    well known file type ID for NWBIgor files is 570280085
 
-    # Try to find NWBIgor file preferentially
+
+    Parameters
+    ----------
+    ephys_roi_result: int
+
+    Returns
+    -------
+    full path of the nwb file
+
+    """
+
     result = query("""
     SELECT f.filename, f.storage_directory FROM well_known_files f
     WHERE f.attachable_type = 'EphysRoiResult' AND f.attachable_id = %s AND f.well_known_file_type_id = 570280085
     """ % (ephys_roi_result,))
 
     if len(result) == 0:
-        # Fall back to looking for NWB type
+        logging.warning("Fall back to looking for NWB type")
 
         result = query("""
         SELECT f.filename, f.storage_directory FROM well_known_files f
         WHERE f.attachable_type = 'EphysRoiResult' AND f.attachable_id = %s AND f.well_known_file_type_id = 475137571
         """ % (ephys_roi_result,))
 
-        if len(result) == 0:
-            logging.info("No result from query to find NWB file")
-            return None
-
     result = result[0]
+
     if result:
         nwb_path = result["storage_directory"] + result["filename"]
         return nwb_path


### PR DESCRIPTION
The processing pipeline no longer automatically produces files named "<specimen_id>.nwb", which are recorded in LIMS with a well-known file type name "NWB". However, LIMS still is recording an entry for those non-existent files, which causes errors downstream.

Therefore, I switched the LIMS query to prefer the "NWBIgor"-type file if that entry exists, and only return an "NWB"-type file if there is no entry for the former.
