### PR TITLE
stop installing pyabf from a fork (changes in mainline)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ argschema
 allensdk
 dictdiffer
 hdmf==1.1.2
-git+https://github.com/nilegraddis/pyABF@version-outside-init#egg=pyabf&subdirectory=src
+pyabf<2.3.0
 pynwb==1.0.2
 six
 watchdog


### PR DESCRIPTION
installing from my fork should no longer be necessary