### PR TITLE
Fix validation of sweeps by using recording epoch

### DIFF
--- a/ipfx/script_utils.py
+++ b/ipfx/script_utils.py
@@ -167,6 +167,7 @@ def categorize_iclamp_sweeps(data_set, stimuli_names, sweep_qc_option="none", sp
 
 def validate_sweeps(data_set, sweep_numbers, extra_dur=0.2):
     check_sweeps = data_set.sweep_set(sweep_numbers)
+    check_sweeps.select_epoch("recording")
     valid_sweep_stim = []
     start = None
     dur = None


### PR DESCRIPTION
We need to set the recording epoch in the `validate_sweeps()` or else it doesn't properly exclude truncated sweeps. 