### PR TITLE
Load h5 file into memory by default

### DIFF
--- a/ipfx/nwb_reader.py
+++ b/ipfx/nwb_reader.py
@@ -5,6 +5,7 @@ from dateutil import parser
 import h5py
 import numpy as np
 from pynwb import NWBHDF5IO
+from io import BytesIO
 from pynwb.icephys import (CurrentClampSeries, CurrentClampStimulusSeries, VoltageClampSeries,
                            VoltageClampStimulusSeries, IZeroClampSeries)
 from ipfx.py2to3 import to_str
@@ -33,8 +34,12 @@ def get_scalar_value(dataset_from_nwb):
 
 class NwbReader(object):
 
-    def __init__(self, nwb_file):
-        self.nwb_file = nwb_file
+    def __init__(self, nwb_file, load_into_memory=True):
+        if load_into_memory:
+            with open(nwb_file, 'rb') as fh:
+                self.nwb_file = BytesIO(fh.read())
+        else:
+            self.nwb_file = nwb_file
 
     def get_sweep_data(self, sweep_number):
         raise NotImplementedError


### PR DESCRIPTION
The `nwb_reader` object ends up making many independent `h5py.File()` calls that add up to a lot of extra processing time. This PR changes the initializer to load the whole file into memory by default, and then uses that in the other methods rather than hitting the file system each time.

By my profiling, the savings are pretty substantial. For a test cell, the time it took to create an `AibsDataSet` object went from ~7 seconds to 1.5 seconds. And it reduced the time the test suite took by at least 30 seconds.