### PR TITLE
ABFConverter: Feature/make json settings file truly optional

### DIFF
--- a/ipfx/bin/run_x_to_nwb_conversion.py
+++ b/ipfx/bin/run_x_to_nwb_conversion.py
@@ -91,7 +91,7 @@ def main():
                                help="Helper for debugging which outputs HTML/TXT files with the metadata contents of the files.")
     common_group.add_argument("--log", type=str, help="Log level for debugging, defaults to the root logger's value.")
     common_group.add_argument("filesOrFolders", nargs="+",
-                               help="List of ABF files/folders to convert.")
+                               help="List of files/folders to convert.")
 
     abf_group.add_argument("--protocolDir", type=str,
                             help=("Disc location where custom waveforms in ATF format are stored."))

--- a/ipfx/bin/run_x_to_nwb_conversion.py
+++ b/ipfx/bin/run_x_to_nwb_conversion.py
@@ -11,7 +11,7 @@ from ipfx.x_to_nwb.DatConverter import DatConverter
 log = logging.getLogger(__name__)
 
 
-def convert(inFileOrFolder, overwrite=False, fileType=None, outputMetadata=False, outputFeedbackChannel=False, multipleGroupsPerFile=False, compression=True):
+def convert(inFileOrFolder, overwrite=False, fileType=None, outputMetadata=False, outputFeedbackChannel=False, multipleGroupsPerFile=False, compression=True, searchSettingsFile=True):
     """
     Convert the given file to a NeuroDataWithoutBorders file using pynwb
 
@@ -26,6 +26,7 @@ def convert(inFileOrFolder, overwrite=False, fileType=None, outputMetadata=False
     :param outputFeedbackChannel: Output ADC data which stems from stimulus feedback channels (ignored for DAT files)
     :param multipleGroupsPerFile: Write all Groups in the DAT file into one NWB
                                   file. By default we create one NWB per Group (ignored for ABF files).
+    :param searchSettingsFile: Search the JSON amplifier settings file and warn if it could not be found (ignored for DAT files)
     :param compression: Toggle compression for HDF5 datasets
 
     :return: path of the created NWB file
@@ -59,7 +60,7 @@ def convert(inFileOrFolder, overwrite=False, fileType=None, outputMetadata=False
         if outputMetadata:
             ABFConverter.outputMetadata(inFileOrFolder)
         else:
-            ABFConverter(inFileOrFolder, outFile, outputFeedbackChannel=outputFeedbackChannel, compression=compression)
+            ABFConverter(inFileOrFolder, outFile, outputFeedbackChannel=outputFeedbackChannel, compression=compression, searchSettingsFile=searchSettingsFile)
     elif ext == ".dat":
         if outputMetadata:
             DatConverter.outputMetadata(inFileOrFolder)
@@ -101,6 +102,8 @@ def main():
                         help="Output ADC data to the NWB file which stems from stimulus feedback channels.")
     abf_group.add_argument("--realDataChannel", type=str, action="append",
                         help=f"Define additional channels which hold non-feedback channel data. The default is {ABFConverter.adcNamesWithRealData}.")
+    abf_group.add_argument("--no-searchSettingsFile", action="store_false", dest="searchSettingsFile", default=True,
+                        help="Don't search the JSON file for the amplifier settings.")
 
     dat_group.add_argument("--multipleGroupsPerFile", action="store_true", default=False,
                            help="Write all Groups from a DAT file into a single NWB file. By default we create one NWB file per Group.")
@@ -133,7 +136,8 @@ def main():
                 outputMetadata=args.outputMetadata,
                 outputFeedbackChannel=args.outputFeedbackChannel,
                 multipleGroupsPerFile=args.multipleGroupsPerFile,
-                compression=args.compression)
+                compression=args.compression,
+                searchSettingsFile=args.searchSettingsFile)
 
 
 if __name__ == "__main__":

--- a/ipfx/x_to_nwb/ABFConverter.py
+++ b/ipfx/x_to_nwb/ABFConverter.py
@@ -10,6 +10,9 @@ import glob
 import warnings
 import logging
 
+from datetime import datetime
+from dateutil.tz import tzlocal
+
 import numpy as np
 
 import pyabf
@@ -307,7 +310,7 @@ class ABFConverter:
             session_description = PLACEHOLDER
 
         identifier = sha256(" ".join([abf.fileGUID for abf in self.abfs]).encode()).hexdigest()
-        session_start_time = self.refabf.abfDateTime
+        session_start_time = datetime.combine(self.refabf.abfDateTime.date(), self.refabf.abfDateTime.time(), tzinfo=tzlocal())
         creatorName = self.refabf._stringsIndexed.uCreatorName
         creatorVersion = formatVersion(self.refabf.creatorVersion)
         experiment_description = (f"{creatorName} v{creatorVersion}")

--- a/ipfx/x_to_nwb/ABFConverter.py
+++ b/ipfx/x_to_nwb/ABFConverter.py
@@ -379,7 +379,7 @@ class ABFConverter:
                     abf.setSweep(sweep, channel=channel, absoluteTime=True)
                     name, counter = createSeriesName("index", counter, total=self.totalSeriesCount)
                     data = convertDataset(abf.sweepC * scale_factor, self.compression)
-                    conversion, unit = parseUnit(abf.sweepUnitsC)
+                    conversion, _ = parseUnit(abf.sweepUnitsC)
                     electrode = electrodes[channel]
                     gain = abf._dacSection.fDACScaleFactor[channel]
                     resolution = np.nan
@@ -399,7 +399,6 @@ class ABFConverter:
                         stimulus = seriesClass(name=name,
                                                data=data,
                                                sweep_number=np.uint64(cycle_id),
-                                               unit=unit,
                                                electrode=electrode,
                                                gain=gain,
                                                resolution=resolution,
@@ -557,7 +556,7 @@ class ABFConverter:
                     abf.setSweep(sweep, channel=channel, absoluteTime=True)
                     name, counter = createSeriesName("index", counter, total=self.totalSeriesCount)
                     data = convertDataset(abf.sweepY, self.compression)
-                    conversion, unit = parseUnit(abf.sweepUnitsY)
+                    conversion, _ = parseUnit(abf.sweepUnitsY)
                     electrode = electrodes[channel]
                     gain = abf._adcSection.fADCProgrammableGain[channel]
                     resolution = np.nan
@@ -579,7 +578,6 @@ class ABFConverter:
                         acquistion_data = seriesClass(name=name,
                                                       data=data,
                                                       sweep_number=np.uint64(cycle_id),
-                                                      unit=unit,
                                                       electrode=electrode,
                                                       gain=gain,
                                                       resolution=resolution,
@@ -600,7 +598,6 @@ class ABFConverter:
                         acquistion_data = seriesClass(name=name,
                                                       data=data,
                                                       sweep_number=np.uint64(cycle_id),
-                                                      unit=unit,
                                                       electrode=electrode,
                                                       gain=gain,
                                                       resolution=resolution,

--- a/ipfx/x_to_nwb/DatConverter.py
+++ b/ipfx/x_to_nwb/DatConverter.py
@@ -512,16 +512,15 @@ class DatConverter:
                         clampMode = DatConverter._getClampMode(ampState, cycle_id, trace)
 
                         if clampMode == V_CLAMP_MODE:
-                            conversion, unit = 1e-3, "V"
+                            conversion = 1e-3
                         elif clampMode == I_CLAMP_MODE:
-                            conversion, unit = 1e-12, "A"
+                            conversion = 1e-12
 
                         seriesClass = getStimulusSeriesClass(clampMode)
 
                         timeSeries = seriesClass(name=name,
                                                  data=data,
                                                  sweep_number=np.uint64(cycle_id),
-                                                 unit=unit,
                                                  electrode=electrode,
                                                  gain=gain,
                                                  resolution=resolution,
@@ -568,7 +567,7 @@ class DatConverter:
                         else:
                             gain = np.nan
 
-                        conversion, unit = parseUnit(trace.YUnit)
+                        conversion, _ = parseUnit(trace.YUnit)
                         electrodeKey = DatConverter._generateElectrodeKey(trace)
                         electrode = electrodes[self.electrodeDict[electrodeKey]]
 
@@ -612,7 +611,6 @@ class DatConverter:
                             acquistion_data = seriesClass(name=name,
                                                           data=data,
                                                           sweep_number=np.uint64(cycle_id),
-                                                          unit=unit,
                                                           electrode=electrode,
                                                           gain=gain,
                                                           resolution=resolution,
@@ -648,7 +646,6 @@ class DatConverter:
                             acquistion_data = seriesClass(name=name,
                                                           data=data,
                                                           sweep_number=np.uint64(cycle_id),
-                                                          unit=unit,
                                                           electrode=electrode,
                                                           gain=gain,
                                                           resolution=resolution,

--- a/ipfx/x_to_nwb/Readme.md
+++ b/ipfx/x_to_nwb/Readme.md
@@ -11,6 +11,23 @@ JSON output.
 
 In case you don't have a JSON settings file pass `--no-searchSettingsFile` to avoid warnings.
 
+For historic reasons the ABF conversion uses a hardcoded list of AD channel names
+which will be written into the NWB file, other channels are discarded.
+
+To turn that behaviour off call the conversion script with
+
+```sh
+run_x_to_nwb_conversion.py --includeChannel "*" 2018_03_20_0000.abf
+```
+
+which outputs all AD channels.
+
+To discard some AD channels (the hardcoded list is ignored in this case) use
+
+```sh
+run_x_to_nwb_conversion.py --discardChannel ABCD 2018_03_20_0000.abf
+```
+
 #### MCC settings gathering
 
 ```sh

--- a/ipfx/x_to_nwb/Readme.md
+++ b/ipfx/x_to_nwb/Readme.md
@@ -9,6 +9,8 @@ To workaround that issue we've developed `mcc_get_settings.py` which gathers
 all amplifier settings from all active amplifiers and writes them to a file in
 JSON output.
 
+In case you don't have a JSON settings file pass `--no-searchSettingsFile` to avoid warnings.
+
 #### MCC settings gathering
 
 ```sh

--- a/tests/test_x_nwb.py
+++ b/tests/test_x_nwb.py
@@ -69,7 +69,7 @@ def test_file_level_regressions(raw_file):
 
     ref_folder = f"reference_{ext[1:]}_nwb"
 
-    new_file = convert(raw_file, overwrite=True, outputFeedbackChannel=True, multipleGroupsPerFile=True)
+    new_file = convert(raw_file, overwrite=True, multipleGroupsPerFile=True)
     ref_file = os.path.join(ref_folder, os.path.basename(new_file))
 
     assert os.path.isfile(ref_file)

--- a/tests/test_x_nwb_helper.py
+++ b/tests/test_x_nwb_helper.py
@@ -108,7 +108,7 @@ def create_files_for_upload(ext):
 
     for f in files:
         print(f"Converting {f}")
-        convert(f, overwrite=True, outputFeedbackChannel=True, multipleGroupsPerFile=True)
+        convert(f, overwrite=True, multipleGroupsPerFile=True)
 
     nwb_folder = basename + "_nwb"
     zip_files(folder, nwb_folder, ".nwb")


### PR DESCRIPTION
@youngseok-seo Please test.

The JSON settings file was never really required, but not passing it in resulted in a bunch of warnings.
You can now pass `no-searchSettingsFile` to avoid the warnings. In addition I've also removed a few other warnings and upgraded to pynwb 1.3.0.

@sgratiy We should discuss if and how we merge PRs from external users.

Close #341.
Close #342.