### PR TITLE
unit tests for feature vector

### DIFF
--- a/tests/test_feature_vector.py
+++ b/tests/test_feature_vector.py
@@ -14,14 +14,24 @@ import os
 from .helpers_for_tests import download_file
 
 
-TEST_OUTPUT_DIR = "/allen/aibs/informatics/module_test_data/ipfx/test_feature_vector"
+TEST_OUTPUT_DIR = os.path.join(
+    "/",
+    "allen",
+    "aibs",
+    "informatics",
+    "module_test_data",
+    "ipfx",
+    "test_feature_vector"
+)
 
-ontology = StimulusOntology(ju.read(StimulusOntology.DEFAULT_STIMULUS_ONTOLOGY_FILE))
+ontology = StimulusOntology(
+    ju.read(StimulusOntology.DEFAULT_STIMULUS_ONTOLOGY_FILE))
+
 
 @pytest.fixture
 def feature_vector_input():
 
-    TEST_DATA_PATH = os.path.join(os.path.dirname(__file__), 'data')
+    TEST_DATA_PATH = os.path.join(os.path.dirname(__file__), "data")
 
     nwb_file_name = "Pvalb-IRES-Cre;Ai14-415796.02.01.01.nwb"
     nwb_file_full_path = os.path.join(TEST_DATA_PATH, nwb_file_name)
@@ -36,32 +46,202 @@ def feature_vector_input():
     lsq_sweeps = data_set.sweep_set(lsq_sweep_numbers)
     lsq_sweeps.select_epoch("recording")
     lsq_sweeps.align_to_start_of_epoch("experiment")
-    lsq_start, lsq_dur, _, _, _ = stf.get_stim_characteristics(lsq_sweeps.sweeps[0].i,
-                                                               lsq_sweeps.sweeps[0].t)
+    lsq_start, lsq_dur, _, _, _ = stf.get_stim_characteristics(
+        lsq_sweeps.sweeps[0].i, lsq_sweeps.sweeps[0].t
+    )
 
     lsq_end = lsq_start + lsq_dur
-    lsq_spx, lsq_spfx = dsf.extractors_for_sweeps(lsq_sweeps,
-                                                  start=lsq_start,
-                                                  end=lsq_end,
-                                                  **dsf.detection_parameters(data_set.LONG_SQUARE))
-    lsq_an = spa.LongSquareAnalysis(lsq_spx, lsq_spfx, subthresh_min_amp=-100.)
+    lsq_spx, lsq_spfx = dsf.extractors_for_sweeps(
+        lsq_sweeps,
+        start=lsq_start,
+        end=lsq_end,
+        **dsf.detection_parameters(data_set.LONG_SQUARE)
+    )
+    lsq_an = spa.LongSquareAnalysis(lsq_spx, lsq_spfx, subthresh_min_amp=-100.0)
 
     lsq_features = lsq_an.analyze(lsq_sweeps)
 
     return lsq_sweeps, lsq_features, lsq_start, lsq_end
 
-@pytest.mark.requires_inhouse_data
-def test_isi_shape(feature_vector_input):
 
-    sweeps, features, start, end = feature_vector_input
+def test_identify_sweep_for_isi_shape():
+    sweeps = {
+        "index": [0, 1, 2, 3, 4, 5, 6, 7, 8],
+        "columns": [
+            "avg_rate",
+            "peak_deflect",
+            "stim_amp",
+            "v_baseline",
+            "sag",
+            "adapt",
+            "latency",
+            "isi_cv",
+            "mean_isi",
+            "median_isi",
+            "first_isi",
+        ],
+        "data": [
+            [
+                0.0,
+                (-70.65, 35892),
+                -29.999998092651367,
+                -68.25825500488281,
+                0.054702017456293106,
+                np.nan,
+                np.nan,
+                np.nan,
+                np.nan,
+                np.nan,
+                np.nan,
+            ],
+            [
+                0.0,
+                (-72.2, 33470),
+                -50.0,
+                -68.39005279541016,
+                0.01751580648124218,
+                np.nan,
+                np.nan,
+                np.nan,
+                np.nan,
+                np.nan,
+                np.nan,
+            ],
+            [
+                0.0,
+                (-73.66875, 79087),
+                -70.0,
+                -68.42821502685547,
+                0.004760173615068197,
+                np.nan,
+                np.nan,
+                np.nan,
+                np.nan,
+                np.nan,
+                np.nan,
+            ],
+            [
+                0.0,
+                (-30.550001, 31322),
+                469.9999694824219,
+                -68.29730987548828,
+                -8.956585884094238,
+                np.nan,
+                np.nan,
+                np.nan,
+                np.nan,
+                np.nan,
+                np.nan,
+            ],
+            [
+                0.0,
+                (-28.54375, 31625),
+                479.9999694824219,
+                -68.26968383789062,
+                -9.093791961669922,
+                np.nan,
+                np.nan,
+                np.nan,
+                np.nan,
+                np.nan,
+                np.nan,
+            ],
+            [
+                5.000000000000001,
+                (14.98125, 30920),
+                489.9999694824219,
+                -67.90441131591797,
+                -8.981210708618164,
+                0.00839006531426236,
+                0.018079999999999985,
+                0.026166652896782595,
+                0.016109999999999985,
+                0.01608000000000004,
+                0.015880000000000005,
+            ],
+            [
+                30.000000000000004,
+                (15.19375, 32169),
+                520.0,
+                -67.4559097290039,
+                -8.814754486083984,
+                0.00801722722893242,
+                0.01963999999999999,
+                0.1548801847128805,
+                0.015706896551724133,
+                0.0156400000000001,
+                0.011479999999999935,
+            ],
+            [
+                72.00000000000001,
+                (15.31875, 31168),
+                540.0,
+                -67.43457794189453,
+                -6.910084247589111,
+                0.001789278456852954,
+                0.012699999999999934,
+                0.09433347064888947,
+                0.013758591549295774,
+                0.013900000000000023,
+                0.010319999999999996,
+            ],
+            [
+                81.00000000000001,
+                (15.7125, 52887),
+                560.0,
+                -67.80497741699219,
+                -6.805542945861816,
+                0.002374929272995164,
+                0.011459999999999915,
+                0.0921604402099859,
+                0.0123335,
+                0.012390000000000012,
+                0.009160000000000057,
+            ],
+        ],
+    }
+    end = 1.5
+    start = 0.5
+
+    class SomeSweeps:
+        @property
+        def sweeps(self):
+            ndata = len(sweeps["data"][3])
+            nsweeps = len(sweeps["index"])
+            return np.arange(nsweeps * ndata).reshape(nsweeps, ndata)
 
     isi_sweep, isi_sweep_spike_info = fv.identify_sweep_for_isi_shape(
-        sweeps, features, end - start)
-    temp_data = fv.isi_shape(isi_sweep, isi_sweep_spike_info, end)
+        SomeSweeps(), 
+        {"sweeps": pd.DataFrame(**sweeps), "spikes_set": {5: "foo"}}, 
+        end - start
+    )
 
-    test_data = np.load(os.path.join(TEST_OUTPUT_DIR, "isi_shape.npy"))
+    assert isi_sweep_spike_info == "foo"
+    assert np.allclose(isi_sweep, np.arange(55, 66))
 
-    assert np.array_equal(test_data, temp_data)
+
+def test_isi_shape():
+
+    sweep_spike_info = {
+        "fast_trough_index": [0, 10, -10000],
+        "threshold_index": [-10000, 10, 20],
+        "threshold_v": [1, 2, -10000]
+    }
+
+    class Sweep:
+        @property
+        def v(self):
+            return np.arange(20)
+        @property
+        def t(self):
+            return np.arange(20)
+
+    obtained = fv.isi_shape(
+        Sweep(), pd.DataFrame(sweep_spike_info), 50, n_points=10)
+    assert np.allclose(
+        np.arange(3.5, 13.5, 1.0),
+        obtained
+    )
 
 
 @pytest.mark.requires_inhouse_data
@@ -69,7 +249,9 @@ def test_step_subthreshold(feature_vector_input):
     sweeps, features, start, end = feature_vector_input
     target_amps = [-90, -70, -50, -30, -10]
 
-    subthresh_hyperpol_dict, _ = fv.identify_subthreshold_hyperpol_with_amplitudes(features, sweeps)
+    subthresh_hyperpol_dict, _ = fv.identify_subthreshold_hyperpol_with_amplitudes(
+        features, sweeps
+    )
     temp_data = fv.step_subthreshold(subthresh_hyperpol_dict, target_amps, start, end)
 
     test_data = np.load(os.path.join(TEST_OUTPUT_DIR, "step_subthresh.npy"))
@@ -83,7 +265,13 @@ def test_step_subthreshold_interpolation():
     test_amps = [-70, -30]
     t = np.arange(6)
     i = np.zeros_like(t)
-    epochs = {"sweep": (0, 5), "test": None, "recording": None, "experiment": None, "stim": None}
+    epochs = {
+        "sweep": (0, 5),
+        "test": None,
+        "recording": None,
+        "experiment": None,
+        "stim": None,
+    }
     sampling_rate = 1
     clamp_mode = "CurrentClamp"
     for a in test_amps:
@@ -91,8 +279,14 @@ def test_step_subthreshold_interpolation():
         test_sweep = Sweep(t, v, i, clamp_mode, sampling_rate, epochs=epochs)
         test_sweep_list.append(test_sweep)
     amp_sweep_dict = dict(zip(test_amps, test_sweep_list))
-    output = fv.step_subthreshold(amp_sweep_dict, target_amps, start=2, end=4,
-        extend_duration=1, subsample_interval=1)
+    output = fv.step_subthreshold(
+        amp_sweep_dict,
+        target_amps,
+        start=2,
+        end=4,
+        extend_duration=1,
+        subsample_interval=1,
+    )
     assert np.all(output[1:3] == -90)
     assert np.array_equal(output[4:8], test_sweep_list[0].v[1:-1])
     assert np.all(output[9:11] == -50)
@@ -105,7 +299,13 @@ def test_subthresh_norm_normalization():
     v = np.random.randn(100)
     t = np.arange(len(v))
     i = np.zeros_like(t)
-    epochs = {"sweep": (0, len(v) - 1), "test": None, "recording": None, "experiment": None, "stim": None}
+    epochs = {
+        "sweep": (0, len(v) - 1),
+        "test": None,
+        "recording": None,
+        "experiment": None,
+        "stim": None,
+    }
     sampling_rate = 1
     clamp_mode = "CurrentClamp"
     test_sweep = Sweep(t, v, i, clamp_mode, sampling_rate, epochs=epochs)
@@ -115,8 +315,15 @@ def test_subthresh_norm_normalization():
 
     amp_sweep_dict = {-10: test_sweep}
     deflect_dict = {-10: (base, deflect_v)}
-    output = fv.subthresh_norm(amp_sweep_dict, deflect_dict, start=t[0], end=t[-1],
-        target_amp=-10, extend_duration=0, subsample_interval=1)
+    output = fv.subthresh_norm(
+        amp_sweep_dict,
+        deflect_dict,
+        start=t[0],
+        end=t[-1],
+        target_amp=-10,
+        extend_duration=0,
+        subsample_interval=1,
+    )
     assert np.isclose(output[0], 0)
     assert np.isclose(np.min(output), -1)
 
@@ -137,7 +344,13 @@ def test_subthresh_depol_norm_normalization():
     v = np.random.randn(100)
     t = np.arange(len(v))
     i = np.zeros_like(t)
-    epochs = {"sweep": (0, len(v) - 1), "test": None, "recording": None, "experiment": None, "stim": None}
+    epochs = {
+        "sweep": (0, len(v) - 1),
+        "test": None,
+        "recording": None,
+        "experiment": None,
+        "stim": None,
+    }
     sampling_rate = 1
     clamp_mode = "CurrentClamp"
     test_sweep = Sweep(t, v, i, clamp_mode, sampling_rate, epochs=epochs)
@@ -148,15 +361,25 @@ def test_subthresh_depol_norm_normalization():
     amp_sweep_dict = {10: test_sweep}
     deflect_dict = {10: (base, deflect_v)}
 
-    output = fv.subthresh_depol_norm(amp_sweep_dict, deflect_dict, start=t[0], end=t[-1],
-        steady_state_interval=1, subsample_interval=1, extend_duration=0)
+    output = fv.subthresh_depol_norm(
+        amp_sweep_dict,
+        deflect_dict,
+        start=t[0],
+        end=t[-1],
+        steady_state_interval=1,
+        subsample_interval=1,
+        extend_duration=0,
+    )
     assert np.isclose(output[0], 0)
     assert np.isclose(output[-1], 1)
+
 
 @pytest.mark.requires_inhouse_data
 def test_subthresh_depol_norm(feature_vector_input):
     sweeps, features, start, end = feature_vector_input
-    amp_sweep_dict, deflect_dict = fv.identify_subthreshold_depol_with_amplitudes(features, sweeps)
+    amp_sweep_dict, deflect_dict = fv.identify_subthreshold_depol_with_amplitudes(
+        features, sweeps
+    )
     temp_data = fv.subthresh_depol_norm(amp_sweep_dict, deflect_dict, start, end)
 
     test_data = np.load(os.path.join(TEST_OUTPUT_DIR, "subthresh_depol_norm.npy"))
@@ -174,7 +397,13 @@ def test_first_ap_correct_section():
     v = np.random.randn(100)
     t = np.arange(len(v))
     i = np.zeros_like(t)
-    epochs = {"sweep": (0, len(v) - 1), "test": None, "recording": None, "experiment": None, "stim": None}
+    epochs = {
+        "sweep": (0, len(v) - 1),
+        "test": None,
+        "recording": None,
+        "experiment": None,
+        "stim": None,
+    }
     sampling_rate = 1
     clamp_mode = "CurrentClamp"
     test_sweep = Sweep(t, v, i, clamp_mode, sampling_rate, epochs=epochs)
@@ -183,10 +412,16 @@ def test_first_ap_correct_section():
     test_info = pd.DataFrame({"threshold_index": np.array([test_spike_index])})
 
     window_length = 5
-    ap_v, ap_dv = fv.first_ap_vectors([test_sweep], [test_info],
-        target_sampling_rate=sampling_rate, window_length=window_length)
+    ap_v, ap_dv = fv.first_ap_vectors(
+        [test_sweep],
+        [test_info],
+        target_sampling_rate=sampling_rate,
+        window_length=window_length,
+    )
 
-    assert np.array_equal(ap_v, test_sweep.v[test_spike_index:test_spike_index + window_length])
+    assert np.array_equal(
+        ap_v, test_sweep.v[test_spike_index : test_spike_index + window_length]
+    )
 
 
 def test_first_ap_resampling():
@@ -194,7 +429,13 @@ def test_first_ap_resampling():
     v = np.random.randn(100)
     t = np.arange(len(v))
     i = np.zeros_like(t)
-    epochs = {"sweep": (0, len(v) - 1), "test": None, "recording": None, "experiment": None, "stim": None}
+    epochs = {
+        "sweep": (0, len(v) - 1),
+        "test": None,
+        "recording": None,
+        "experiment": None,
+        "stim": None,
+    }
     sampling_rate = 1
     clamp_mode = "CurrentClamp"
     test_sweep = Sweep(t, v, i, clamp_mode, sampling_rate, epochs=epochs)
@@ -203,8 +444,12 @@ def test_first_ap_resampling():
     test_info = pd.DataFrame({"threshold_index": np.array([test_spike_index])})
 
     window_length = 10
-    ap_v, ap_dv = fv.first_ap_vectors([test_sweep], [test_info],
-        target_sampling_rate=sampling_rate / 2, window_length=window_length)
+    ap_v, ap_dv = fv.first_ap_vectors(
+        [test_sweep],
+        [test_info],
+        target_sampling_rate=sampling_rate / 2,
+        window_length=window_length,
+    )
 
     assert ap_v.shape[0] == window_length / 2
 
@@ -249,13 +494,10 @@ def test_psth_number_of_spikes():
 
 
 def test_psth_between_sweep_interpolation():
-    feature = "test_feature_name"
     test_spike_times = ([0.25, 0.75], [0.2, 0.5, 0.6, 0.7])
     available_list = []
     for tst in test_spike_times:
-        spike_info = pd.DataFrame({
-            "threshold_t": tst,
-        })
+        spike_info = pd.DataFrame({"threshold_t": tst,})
         available_list.append(spike_info)
 
     start = 0
@@ -264,13 +506,18 @@ def test_psth_between_sweep_interpolation():
     n_bins = int((end - start) / (width * 0.001))
 
     si_list = [None, available_list[0], None, available_list[1], None]
-    output = fv.psth_vector(si_list,
-        start=start, end=end, width=width)
+    output = fv.psth_vector(si_list, start=start, end=end, width=width)
 
-    assert np.array_equal(output[:n_bins], output[n_bins:2 * n_bins])
-    assert np.array_equal(output[3 * n_bins:4 * n_bins], output[4 * n_bins:5 * n_bins])
-    assert np.array_equal(output[2 * n_bins:3 * n_bins],
-        np.vstack([output[n_bins:2 * n_bins], output[4 * n_bins:5 * n_bins]]).mean(axis=0))
+    assert np.array_equal(output[:n_bins], output[n_bins: 2 * n_bins])
+    assert np.array_equal(
+        output[3 * n_bins: 4 * n_bins], output[4 * n_bins: 5 * n_bins]
+    )
+    assert np.array_equal(
+        output[2 * n_bins : 3 * n_bins],
+        np.vstack([output[n_bins: 2 * n_bins], output[4 * n_bins: 5 * n_bins]]).mean(
+            axis=0
+        ),
+    )
 
 
 def test_inst_freq_one_spike():
@@ -290,7 +537,7 @@ def test_inst_freq_initial_freq():
     end = 1
     width = 20
     output = fv.inst_freq_vector([spike_info], start=start, end=end, width=width)
-    assert output[0] == 1. / (test_spike_times[0] - start)
+    assert output[0] == 1.0 / (test_spike_times[0] - start)
 
 
 def test_inst_freq_between_sweep_interpolation():
@@ -298,9 +545,7 @@ def test_inst_freq_between_sweep_interpolation():
     test_spike_times = ([0.25, 0.75], [0.2, 0.5, 0.6, 0.7])
     available_list = []
     for tst in test_spike_times:
-        spike_info = pd.DataFrame({
-            "threshold_t": tst,
-        })
+        spike_info = pd.DataFrame({"threshold_t": tst,})
         available_list.append(spike_info)
 
     start = 0
@@ -309,29 +554,37 @@ def test_inst_freq_between_sweep_interpolation():
     n_bins = int((end - start) / (width * 0.001))
 
     si_list = [None, available_list[0], None, available_list[1], None]
-    output = fv.inst_freq_vector(si_list,
-        start=start, end=end, width=width)
+    output = fv.inst_freq_vector(si_list, start=start, end=end, width=width)
 
-    assert np.array_equal(output[:n_bins], output[n_bins:2 * n_bins])
-    assert np.array_equal(output[3 * n_bins:4 * n_bins], output[4 * n_bins:5 * n_bins])
-    assert np.array_equal(output[2 * n_bins:3 * n_bins],
-        np.vstack([output[n_bins:2 * n_bins], output[4 * n_bins:5 * n_bins]]).mean(axis=0))
+    assert np.array_equal(output[:n_bins], output[n_bins : 2 * n_bins])
+    assert np.array_equal(
+        output[3 * n_bins : 4 * n_bins], output[4 * n_bins : 5 * n_bins]
+    )
+    assert np.array_equal(
+        output[2 * n_bins : 3 * n_bins],
+        np.vstack([output[n_bins : 2 * n_bins], output[4 * n_bins : 5 * n_bins]]).mean(
+            axis=0
+        ),
+    )
 
 
 def test_spike_feature_within_sweep_interpolation():
     feature = "test_feature_name"
     test_spike_times = [0.25, 0.75]
     test_feature_values = [1, 2]
-    spike_info = pd.DataFrame({
-        "threshold_t": test_spike_times,
-        "clipped": np.zeros(2).astype(bool),
-        feature: test_feature_values,
-    })
+    spike_info = pd.DataFrame(
+        {
+            "threshold_t": test_spike_times,
+            "clipped": np.zeros(2).astype(bool),
+            feature: test_feature_values,
+        }
+    )
     start = 0
     end = 1
     width = 20
-    output = fv.spike_feature_vector(feature, [spike_info],
-        start=start, end=end, width=width)
+    output = fv.spike_feature_vector(
+        feature, [spike_info], start=start, end=end, width=width
+    )
     assert output[0] == test_feature_values[0]
     assert output[len(output) // 2] > test_feature_values[0]
     assert output[len(output) // 2] < test_feature_values[-1]
@@ -344,11 +597,13 @@ def test_spike_feature_between_sweep_interpolation():
     test_feature_values = [1, 2]
     available_list = []
     for val in test_feature_values:
-        spike_info = pd.DataFrame({
-            "threshold_t": test_spike_times,
-            "clipped": np.zeros(2).astype(bool),
-            feature: [val] * 2,
-        })
+        spike_info = pd.DataFrame(
+            {
+                "threshold_t": test_spike_times,
+                "clipped": np.zeros(2).astype(bool),
+                feature: [val] * 2,
+            }
+        )
         available_list.append(spike_info)
 
     start = 0
@@ -356,30 +611,45 @@ def test_spike_feature_between_sweep_interpolation():
     width = 20
     n_bins = int((end - start) / (width * 0.001))
     si_list = [None, available_list[0], None, available_list[1], None]
-    output = fv.spike_feature_vector(feature, si_list,
-        start=start, end=end, width=width)
+    output = fv.spike_feature_vector(
+        feature, si_list, start=start, end=end, width=width
+    )
     assert np.all(output[:n_bins] == test_feature_values[0])
-    assert np.all(output[n_bins:2 * n_bins] == test_feature_values[0])
-    assert np.all(output[2 * n_bins:3 * n_bins] == np.mean(test_feature_values))
-    assert np.all(output[3 * n_bins:4 * n_bins] == test_feature_values[1])
-    assert np.all(output[4 * n_bins:5 * n_bins] == test_feature_values[1])
+    assert np.all(output[n_bins : 2 * n_bins] == test_feature_values[0])
+    assert np.all(output[2 * n_bins : 3 * n_bins] == np.mean(test_feature_values))
+    assert np.all(output[3 * n_bins : 4 * n_bins] == test_feature_values[1])
+    assert np.all(output[4 * n_bins : 5 * n_bins] == test_feature_values[1])
 
 
 def test_identify_sub_hyperpol_levels():
     test_input_amplitudes = [-2000, -100, -90, -50, -10, 10]
-    test_features = {"subthreshold_sweeps": pd.DataFrame({
-        "stim_amp": test_input_amplitudes,
-        "peak_deflect": list(zip(np.zeros(len(test_input_amplitudes)),
-            np.zeros(len(test_input_amplitudes)))),
-        "v_baseline": np.ones(len(test_input_amplitudes)),
-    })}
+    test_features = {
+        "subthreshold_sweeps": pd.DataFrame(
+            {
+                "stim_amp": test_input_amplitudes,
+                "peak_deflect": list(
+                    zip(
+                        np.zeros(len(test_input_amplitudes)),
+                        np.zeros(len(test_input_amplitudes)),
+                    )
+                ),
+                "v_baseline": np.ones(len(test_input_amplitudes)),
+            }
+        )
+    }
 
     # Random test sweeps
     np.random.seed(42)
     v = np.random.randn(100)
     t = np.arange(len(v))
     i = np.zeros_like(t)
-    epochs = {"sweep": (0, len(v) - 1), "test": None, "recording": None, "experiment": None, "stim": None}
+    epochs = {
+        "sweep": (0, len(v) - 1),
+        "test": None,
+        "recording": None,
+        "experiment": None,
+        "stim": None,
+    }
     sampling_rate = 1
     clamp_mode = "CurrentClamp"
     sweep_list = []
@@ -389,7 +659,8 @@ def test_identify_sub_hyperpol_levels():
     test_sweep_set = SweepSet(sweep_list)
 
     amp_sweep_dict, deflect_dict = fv.identify_subthreshold_hyperpol_with_amplitudes(
-        test_features, test_sweep_set)
+        test_features, test_sweep_set
+    )
 
     for k in amp_sweep_dict:
         assert k in deflect_dict
@@ -410,19 +681,33 @@ def test_identify_sub_hyperpol_levels():
 
 def test_identify_sub_depol_levels_with_subthreshold_sweeps():
     test_input_amplitudes = [-50, -10, 10, 20]
-    test_features = {"subthreshold_sweeps": pd.DataFrame({
-        "stim_amp": test_input_amplitudes,
-        "peak_deflect": list(zip(np.zeros(len(test_input_amplitudes)),
-            np.zeros(len(test_input_amplitudes)))),
-        "v_baseline": np.ones(len(test_input_amplitudes)),
-    })}
+    test_features = {
+        "subthreshold_sweeps": pd.DataFrame(
+            {
+                "stim_amp": test_input_amplitudes,
+                "peak_deflect": list(
+                    zip(
+                        np.zeros(len(test_input_amplitudes)),
+                        np.zeros(len(test_input_amplitudes)),
+                    )
+                ),
+                "v_baseline": np.ones(len(test_input_amplitudes)),
+            }
+        )
+    }
 
     # Random test sweeps
     np.random.seed(42)
     v = np.random.randn(100)
     t = np.arange(len(v))
     i = np.zeros_like(t)
-    epochs = {"sweep": (0, len(v) - 1), "test": None, "recording": None, "experiment": None, "stim": None}
+    epochs = {
+        "sweep": (0, len(v) - 1),
+        "test": None,
+        "recording": None,
+        "experiment": None,
+        "stim": None,
+    }
     sampling_rate = 1
     clamp_mode = "CurrentClamp"
     sweep_list = []
@@ -432,7 +717,8 @@ def test_identify_sub_depol_levels_with_subthreshold_sweeps():
     test_sweep_set = SweepSet(sweep_list)
 
     amp_sweep_dict, deflect_dict = fv.identify_subthreshold_depol_with_amplitudes(
-        test_features, test_sweep_set)
+        test_features, test_sweep_set
+    )
 
     for k in amp_sweep_dict:
         assert k in deflect_dict
@@ -450,20 +736,34 @@ def test_identify_sub_depol_levels_with_subthreshold_sweeps():
 def test_identify_sub_depol_levels_without_subthreshold_sweeps():
     test_input_amplitudes = [-50, -10, 10, 20]
     test_avg_rate = [0, 0, 0, 5]
-    test_features = {"sweeps": pd.DataFrame({
-        "stim_amp": test_input_amplitudes,
-        "peak_deflect": list(zip(np.zeros(len(test_input_amplitudes)),
-            np.zeros(len(test_input_amplitudes)))),
-        "v_baseline": np.ones(len(test_input_amplitudes)),
-        "avg_rate": test_avg_rate,
-    })}
+    test_features = {
+        "sweeps": pd.DataFrame(
+            {
+                "stim_amp": test_input_amplitudes,
+                "peak_deflect": list(
+                    zip(
+                        np.zeros(len(test_input_amplitudes)),
+                        np.zeros(len(test_input_amplitudes)),
+                    )
+                ),
+                "v_baseline": np.ones(len(test_input_amplitudes)),
+                "avg_rate": test_avg_rate,
+            }
+        )
+    }
 
     # Random test sweeps
     np.random.seed(42)
     v = np.random.randn(100)
     t = np.arange(len(v))
     i = np.zeros_like(t)
-    epochs = {"sweep": (0, len(v) - 1), "test": None, "recording": None, "experiment": None, "stim": None}
+    epochs = {
+        "sweep": (0, len(v) - 1),
+        "test": None,
+        "recording": None,
+        "experiment": None,
+        "stim": None,
+    }
     sampling_rate = 1
     clamp_mode = "CurrentClamp"
     sweep_list = []
@@ -473,19 +773,22 @@ def test_identify_sub_depol_levels_without_subthreshold_sweeps():
     test_sweep_set = SweepSet(sweep_list)
 
     amp_sweep_dict, deflect_dict = fv.identify_subthreshold_depol_with_amplitudes(
-        test_features, test_sweep_set)
+        test_features, test_sweep_set
+    )
 
     for k in amp_sweep_dict:
         assert k in deflect_dict
         assert len(deflect_dict[k]) == 2
 
-    depolarizing_spiking = [a for a, r in zip(test_input_amplitudes, test_avg_rate)
-         if a > 0 and r > 0]
+    depolarizing_spiking = [
+        a for a, r in zip(test_input_amplitudes, test_avg_rate) if a > 0 and r > 0
+    ]
     for a in depolarizing_spiking:
         assert a not in amp_sweep_dict
 
-    depolarizing_non_spiking = [a for a, r in zip(test_input_amplitudes, test_avg_rate)
-         if a > 0 and r == 0]
+    depolarizing_non_spiking = [
+        a for a, r in zip(test_input_amplitudes, test_avg_rate) if a > 0 and r == 0
+    ]
     for a in depolarizing_non_spiking:
         assert a in amp_sweep_dict
 
@@ -500,10 +803,9 @@ def test_identify_isi_shape_min_spike():
     test_input_amplitudes = [10, 20, 30, 40, 50, 60]
     test_avg_rate = [0, 1, 5, 5, 10, 20]
     test_features = {
-        "sweeps": pd.DataFrame({
-            "stim_amp": test_input_amplitudes,
-            "avg_rate": test_avg_rate,
-        }),
+        "sweeps": pd.DataFrame(
+            {"stim_amp": test_input_amplitudes, "avg_rate": test_avg_rate,}
+        ),
         "spikes_set": [None] * len(test_avg_rate),
     }
 
@@ -512,7 +814,13 @@ def test_identify_isi_shape_min_spike():
     n_points = 100
     t = np.arange(n_points)
     i = np.zeros_like(t)
-    epochs = {"sweep": (0, n_points - 1), "test": None, "recording": None, "experiment": None, "stim": None}
+    epochs = {
+        "sweep": (0, n_points - 1),
+        "test": None,
+        "recording": None,
+        "experiment": None,
+        "stim": None,
+    }
     sampling_rate = 1
     clamp_mode = "CurrentClamp"
     sweep_list = []
@@ -523,7 +831,8 @@ def test_identify_isi_shape_min_spike():
     test_sweep_set = SweepSet(sweep_list)
 
     selected_sweep, _ = fv.identify_sweep_for_isi_shape(
-        test_sweep_set, test_features, duration=1, min_spike=min_spike)
+        test_sweep_set, test_features, duration=1, min_spike=min_spike
+    )
 
     assert np.array_equal(selected_sweep.v, sweep_list[2].v)
 
@@ -534,10 +843,9 @@ def test_identify_isi_shape_largest_below_min_spike():
     test_input_amplitudes = [10, 20, 30, 40]
     test_avg_rate = [0, 1, 3, 4]
     test_features = {
-        "sweeps": pd.DataFrame({
-            "stim_amp": test_input_amplitudes,
-            "avg_rate": test_avg_rate,
-        }),
+        "sweeps": pd.DataFrame(
+            {"stim_amp": test_input_amplitudes, "avg_rate": test_avg_rate,}
+        ),
         "spikes_set": [None] * len(test_avg_rate),
     }
 
@@ -546,7 +854,13 @@ def test_identify_isi_shape_largest_below_min_spike():
     n_points = 100
     t = np.arange(n_points)
     i = np.zeros_like(t)
-    epochs = {"sweep": (0, n_points - 1), "test": None, "recording": None, "experiment": None, "stim": None}
+    epochs = {
+        "sweep": (0, n_points - 1),
+        "test": None,
+        "recording": None,
+        "experiment": None,
+        "stim": None,
+    }
     sampling_rate = 1
     clamp_mode = "CurrentClamp"
     sweep_list = []
@@ -557,7 +871,8 @@ def test_identify_isi_shape_largest_below_min_spike():
     test_sweep_set = SweepSet(sweep_list)
 
     selected_sweep, _ = fv.identify_sweep_for_isi_shape(
-        test_sweep_set, test_features, duration=1, min_spike=min_spike)
+        test_sweep_set, test_features, duration=1, min_spike=min_spike
+    )
 
     assert np.array_equal(selected_sweep.v, sweep_list[-1].v)
 
@@ -568,10 +883,9 @@ def test_identify_isi_shape_one_spike():
     test_input_amplitudes = [10, 20, 30, 40]
     test_avg_rate = [0, 1, 1, 1]
     test_features = {
-        "sweeps": pd.DataFrame({
-            "stim_amp": test_input_amplitudes,
-            "avg_rate": test_avg_rate,
-        }),
+        "sweeps": pd.DataFrame(
+            {"stim_amp": test_input_amplitudes, "avg_rate": test_avg_rate,}
+        ),
         "spikes_set": [None] * len(test_avg_rate),
     }
 
@@ -580,7 +894,13 @@ def test_identify_isi_shape_one_spike():
     n_points = 100
     t = np.arange(n_points)
     i = np.zeros_like(t)
-    epochs = {"sweep": (0, n_points - 1), "test": None, "recording": None, "experiment": None, "stim": None}
+    epochs = {
+        "sweep": (0, n_points - 1),
+        "test": None,
+        "recording": None,
+        "experiment": None,
+        "stim": None,
+    }
     sampling_rate = 1
     clamp_mode = "CurrentClamp"
     sweep_list = []
@@ -591,7 +911,8 @@ def test_identify_isi_shape_one_spike():
     test_sweep_set = SweepSet(sweep_list)
 
     selected_sweep, _ = fv.identify_sweep_for_isi_shape(
-        test_sweep_set, test_features, duration=1, min_spike=min_spike)
+        test_sweep_set, test_features, duration=1, min_spike=min_spike
+    )
 
     assert np.array_equal(selected_sweep.v, sweep_list[1].v)
 
@@ -600,16 +921,16 @@ def test_identify_supra_no_tolerance():
     test_input_amplitudes = [10, 20, 30, 40]
     test_avg_rate = [0, 1, 5, 10]
     test_features = {
-        "spiking_sweeps": pd.DataFrame({
-            "stim_amp": test_input_amplitudes,
-            "avg_rate": test_avg_rate,
-        }),
+        "spiking_sweeps": pd.DataFrame(
+            {"stim_amp": test_input_amplitudes, "avg_rate": test_avg_rate,}
+        ),
         "rheobase_i": 20,
     }
 
     target_amplitudes = np.array([0, 20])
     sweeps_to_use = fv._identify_suprathreshold_indices(
-        test_features, target_amplitudes, shift=None, amp_tolerance=0)
+        test_features, target_amplitudes, shift=None, amp_tolerance=0
+    )
 
     assert sweeps_to_use == [1, 3]
 
@@ -618,16 +939,16 @@ def test_identify_supra_tolerance():
     test_input_amplitudes = [10, 20, 30, 45]
     test_avg_rate = [0, 1, 5, 10]
     test_features = {
-        "spiking_sweeps": pd.DataFrame({
-            "stim_amp": test_input_amplitudes,
-            "avg_rate": test_avg_rate,
-        }),
+        "spiking_sweeps": pd.DataFrame(
+            {"stim_amp": test_input_amplitudes, "avg_rate": test_avg_rate,}
+        ),
         "rheobase_i": 20,
     }
 
     target_amplitudes = np.array([0, 20])
     sweeps_to_use = fv._identify_suprathreshold_indices(
-        test_features, target_amplitudes, shift=None, amp_tolerance=5)
+        test_features, target_amplitudes, shift=None, amp_tolerance=5
+    )
 
     assert sweeps_to_use == [1, 3]
 
@@ -636,16 +957,16 @@ def test_identify_supra_shift():
     test_input_amplitudes = [10, 20, 40, 60]
     test_avg_rate = [1, 2, 5, 10]
     test_features = {
-        "spiking_sweeps": pd.DataFrame({
-            "stim_amp": test_input_amplitudes,
-            "avg_rate": test_avg_rate,
-        }),
+        "spiking_sweeps": pd.DataFrame(
+            {"stim_amp": test_input_amplitudes, "avg_rate": test_avg_rate,}
+        ),
         "rheobase_i": 10,
     }
 
     target_amplitudes = np.array([0, 20, 40])
     sweeps_to_use = fv._identify_suprathreshold_indices(
-        test_features, target_amplitudes, shift=10, amp_tolerance=5)
+        test_features, target_amplitudes, shift=10, amp_tolerance=5
+    )
 
     assert sweeps_to_use == [1, 2, 3]
 
@@ -656,7 +977,13 @@ def test_isi_shape_aligned():
     v = np.random.randn(1000)
     t = np.arange(len(v))
     i = np.zeros_like(t)
-    epochs = {"sweep": (0, len(v) - 1), "test": None, "recording": None, "experiment": None, "stim": None}
+    epochs = {
+        "sweep": (0, len(v) - 1),
+        "test": None,
+        "recording": None,
+        "experiment": None,
+        "stim": None,
+    }
     sampling_rate = 1
     clamp_mode = "CurrentClamp"
     test_sweep = Sweep(t, v, i, clamp_mode, sampling_rate, epochs=epochs)
@@ -666,17 +993,21 @@ def test_isi_shape_aligned():
     test_fast_trough_index = test_threshold_index + 20
     test_threshold_v = np.random.randint(-100, -20, size=len(test_threshold_index))
 
-    test_spike_info = pd.DataFrame({
-        "threshold_index": test_threshold_index,
-        "fast_trough_index": test_fast_trough_index,
-        "threshold_v": test_threshold_v,
-        "fast_trough_t": test_fast_trough_index,
-    })
+    test_spike_info = pd.DataFrame(
+        {
+            "threshold_index": test_threshold_index,
+            "fast_trough_index": test_fast_trough_index,
+            "threshold_v": test_threshold_v,
+            "fast_trough_t": test_fast_trough_index,
+        }
+    )
 
     n_points = 100
     isi_norm = fv.isi_shape(test_sweep, test_spike_info, end, n_points=n_points)
     assert len(isi_norm) == n_points
-    assert isi_norm[0] == np.mean(test_sweep.v[test_fast_trough_index[:-1]] - test_threshold_v[:-1])
+    assert isi_norm[0] == np.mean(
+        test_sweep.v[test_fast_trough_index[:-1]] - test_threshold_v[:-1]
+    )
 
 
 def test_isi_shape_aligned():
@@ -685,7 +1016,13 @@ def test_isi_shape_aligned():
     v = np.random.randn(1000)
     t = np.arange(len(v))
     i = np.zeros_like(t)
-    epochs = {"sweep": (0, len(v) - 1), "test": None, "recording": None, "experiment": None, "stim": None}
+    epochs = {
+        "sweep": (0, len(v) - 1),
+        "test": None,
+        "recording": None,
+        "experiment": None,
+        "stim": None,
+    }
     sampling_rate = 1
     clamp_mode = "CurrentClamp"
     test_sweep = Sweep(t, v, i, clamp_mode, sampling_rate, epochs=epochs)
@@ -695,17 +1032,21 @@ def test_isi_shape_aligned():
     test_fast_trough_index = test_threshold_index + 20
     test_threshold_v = np.random.randint(-100, -20, size=len(test_threshold_index))
 
-    test_spike_info = pd.DataFrame({
-        "threshold_index": test_threshold_index,
-        "fast_trough_index": test_fast_trough_index,
-        "threshold_v": test_threshold_v,
-        "fast_trough_t": test_fast_trough_index,
-    })
+    test_spike_info = pd.DataFrame(
+        {
+            "threshold_index": test_threshold_index,
+            "fast_trough_index": test_fast_trough_index,
+            "threshold_v": test_threshold_v,
+            "fast_trough_t": test_fast_trough_index,
+        }
+    )
 
     n_points = 100
     isi_norm = fv.isi_shape(test_sweep, test_spike_info, end, n_points=n_points)
     assert len(isi_norm) == n_points
-    assert isi_norm[0] == np.mean(test_sweep.v[test_fast_trough_index[:-1]] - test_threshold_v[:-1])
+    assert isi_norm[0] == np.mean(
+        test_sweep.v[test_fast_trough_index[:-1]] - test_threshold_v[:-1]
+    )
 
 
 def test_isi_shape_skip_short():
@@ -714,7 +1055,13 @@ def test_isi_shape_skip_short():
     v = np.random.randn(1000)
     t = np.arange(len(v))
     i = np.zeros_like(t)
-    epochs = {"sweep": (0, len(v) - 1), "test": None, "recording": None, "experiment": None, "stim": None}
+    epochs = {
+        "sweep": (0, len(v) - 1),
+        "test": None,
+        "recording": None,
+        "experiment": None,
+        "stim": None,
+    }
     sampling_rate = 1
     clamp_mode = "CurrentClamp"
     test_sweep = Sweep(t, v, i, clamp_mode, sampling_rate, epochs=epochs)
@@ -725,20 +1072,26 @@ def test_isi_shape_skip_short():
     test_fast_trough_index = test_threshold_index + 20
     test_threshold_v = np.random.randint(-100, -20, size=len(test_threshold_index))
 
-    test_spike_info = pd.DataFrame({
-        "threshold_index": test_threshold_index,
-        "fast_trough_index": test_fast_trough_index,
-        "threshold_v": test_threshold_v,
-        "fast_trough_t": test_fast_trough_index,
-    })
+    test_spike_info = pd.DataFrame(
+        {
+            "threshold_index": test_threshold_index,
+            "fast_trough_index": test_fast_trough_index,
+            "threshold_v": test_threshold_v,
+            "fast_trough_t": test_fast_trough_index,
+        }
+    )
 
     n_points = 100
     isi_norm = fv.isi_shape(test_sweep, test_spike_info, end, n_points=n_points)
     assert len(isi_norm) == n_points
 
     # Should only use second ISI
-    assert isi_norm[0] == (test_sweep.v[test_fast_trough_index[1]:test_fast_trough_index[1] + test_subsample].mean()
-        - test_threshold_v[1])
+    assert isi_norm[0] == (
+        test_sweep.v[
+            test_fast_trough_index[1] : test_fast_trough_index[1] + test_subsample
+        ].mean()
+        - test_threshold_v[1]
+    )
 
 
 def test_isi_shape_one_spike():
@@ -749,7 +1102,13 @@ def test_isi_shape_one_spike():
     print(v[280:300])
     t = np.arange(len(v))
     i = np.zeros_like(t)
-    epochs = {"sweep": (0, len(v) - 1), "test": None, "recording": None, "experiment": None, "stim": None}
+    epochs = {
+        "sweep": (0, len(v) - 1),
+        "test": None,
+        "recording": None,
+        "experiment": None,
+        "stim": None,
+    }
     sampling_rate = 1
     clamp_mode = "CurrentClamp"
     test_sweep = Sweep(t, v, i, clamp_mode, sampling_rate, epochs=epochs)
@@ -759,16 +1118,24 @@ def test_isi_shape_one_spike():
     test_fast_trough_index = [100]
     test_threshold_v = [0]
 
-    test_spike_info = pd.DataFrame({
-        "threshold_index": test_threshold_index,
-        "fast_trough_index": test_fast_trough_index,
-        "threshold_v": test_threshold_v,
-        "fast_trough_t": test_fast_trough_index,
-    })
+    test_spike_info = pd.DataFrame(
+        {
+            "threshold_index": test_threshold_index,
+            "fast_trough_index": test_fast_trough_index,
+            "threshold_v": test_threshold_v,
+            "fast_trough_t": test_fast_trough_index,
+        }
+    )
 
     n_points = 100
-    isi_norm = fv.isi_shape(test_sweep, test_spike_info, end, n_points=n_points,
-        steady_state_interval=10, single_max_duration=500)
+    isi_norm = fv.isi_shape(
+        test_sweep,
+        test_spike_info,
+        end,
+        n_points=n_points,
+        steady_state_interval=10,
+        single_max_duration=500,
+    )
     assert len(isi_norm) == n_points
 
     assert isi_norm[0] < 0


### PR DESCRIPTION
Some of the tests for the feature vector code are written as integration tests when they ought to be unit tests - they load up data from an nwb file and then call multiple functions in sequence. Much of this data is irrelevant to the functions being called, and the dependence on an nwb file makes these tests hard to run outside the institute (and hard to update for the move to nwb2). This pr replaces these tests with focused unit tests.