### PR TITLE
add deprecation warnings in preparation for 1.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,11 @@ Output:
  * log.txt: run log
  * qc_figs: index.html includes cell figures and feature table and sweep.html includes sweep figures
 
+
+Deprecation Warning
+-------------------
+We are working towards a 1.0.0 release of ipfx! This will bring some new features, like NWB2 support, along with improvements to our documentation and testing. We will also drop support for
+- NWB1
+- Python 2
+
+Older versions of ipfx will continue to be available, but will receive only occasional bugfixes and patches.

--- a/ipfx/data_set_utils.py
+++ b/ipfx/data_set_utils.py
@@ -25,7 +25,8 @@ def create_data_set(sweep_info=None, nwb_file=None, ontology=None, api_sweeps=Tr
                           nwb_file=nwb_file,
                           ontology=ontology,
                           api_sweeps=api_sweeps,
-                          validate_stim=validate_stim)
+                          validate_stim=validate_stim,
+                          deprecation_warning=False)
 
     elif nwb_version["major"] == 1 or nwb_version["major"] == 0:
         return AibsDataSet(sweep_info=sweep_info,
@@ -33,7 +34,8 @@ def create_data_set(sweep_info=None, nwb_file=None, ontology=None, api_sweeps=Tr
                            ontology=ontology,
                            api_sweeps=api_sweeps,
                            h5_file=h5_file,
-                           validate_stim=validate_stim)
+                           validate_stim=validate_stim,
+                           deprecation_warning=False)
     else:
         raise ValueError("Unsupported or unknown NWB major" +
                          "version {} ({})".format(nwb_version["major"], nwb_version["full"]))

--- a/ipfx/ephys_data_set.py
+++ b/ipfx/ephys_data_set.py
@@ -2,7 +2,8 @@ import warnings
 import logging
 import pandas as pd
 import numpy as np
-from ipfx.sweep import Sweep,SweepSet
+
+from ipfx.sweep import Sweep, SweepSet
 
 class EphysDataSet(object):
 
@@ -30,24 +31,49 @@ class EphysDataSet(object):
     VOLTAGE_CLAMP = "VoltageClamp"
     CURRENT_CLAMP = "CurrentClamp"
 
-    def __init__(self, ontology, validate_stim=True):
+    def __init__(
+            self, 
+            ontology, 
+            validate_stim=True, 
+            deprecation_warning=False
+    ):
         self.sweep_table = None
         self.ontology = ontology
         self.validate_stim = validate_stim
 
+        if deprecation_warning:
+            warnings.warn(np.VisibleDeprecationWarning((
+                "Instead of constructing {} instances "
+                "directly, use ipfx.data_set_utils.create_data_set"
+                "this will make it easier to transition to ipfx 1.0.0"
+            ).format(type(self))))
+
     @property
     def nwb_data(self):
-        raise NotImplementedError
+        warnings.warn(np.VisibleDeprecationWarning(
+                "In ipfx 1.0.0 nwb_data will not be a public attribute of "
+                "EphysDataSet"
+        ))
+        return self._nwb_data
 
-    def build_sweep_table(self, sweep_info=None):
+    
+    def build_sweep_table(self, sweep_info=None, deprecation_warning=True):
+
+        if deprecation_warning:
+            warnings.warn(np.VisibleDeprecationWarning(
+                "in ipfx version 1.0.0 build_sweep_table will not be a "
+                "public method of EphysDataSet"
+            ))
 
         if sweep_info:
-            self.add_clamp_mode(sweep_info)
+            self.add_clamp_mode(
+                sweep_info, deprecation_warning=deprecation_warning
+            )
             self.sweep_table = pd.DataFrame.from_records(sweep_info)
         else:
             self.sweep_table = pd.DataFrame(columns=self.COLUMN_NAMES)
 
-    def add_clamp_mode(self, sweep_info):
+    def add_clamp_mode(self, sweep_info, deprecation_warning=True):
         """
         Check if clamp mode is available and otherwise detect it
         Parameters
@@ -58,6 +84,12 @@ class EphysDataSet(object):
         -------
 
         """
+
+        if deprecation_warning:
+            warnings.warn(np.VisibleDeprecationWarning(
+                "in ipfx version 1.0.0 add_clamp_mode will not be a "
+                "public method of EphysDataSet"
+            ))
 
         for sweep_record in sweep_info:
             sweep_number = sweep_record["sweep_number"]
@@ -219,7 +251,7 @@ class EphysDataSet(object):
         }
         """
 
-        sweep_data = self.nwb_data.get_sweep_data(sweep_number)
+        sweep_data = self._nwb_data.get_sweep_data(sweep_number)
 
         response = sweep_data['response']
 

--- a/ipfx/hbg_dataset.py
+++ b/ipfx/hbg_dataset.py
@@ -1,24 +1,31 @@
 import pandas as pd
 import numpy as np
 import logging
+import warnings
 import ipfx.nwb_reader as nwb_reader
 
 from .ephys_data_set import EphysDataSet
 
 
 class HBGDataSet(EphysDataSet):
-    def __init__(self, sweep_info=None, nwb_file=None, ontology=None, api_sweeps=True, validate_stim=True):
-        super(HBGDataSet, self).__init__(ontology, validate_stim)
+    def __init__(
+            self, 
+            sweep_info=None, 
+            nwb_file=None, 
+            ontology=None, 
+            api_sweeps=True, 
+            validate_stim=True,
+            deprecation_warning=True
+    ):
+        super(HBGDataSet, self).__init__(
+            ontology, validate_stim, deprecation_warning=deprecation_warning
+        )
         self._nwb_data = nwb_reader.create_nwb_reader(nwb_file)
 
         if sweep_info is None:
             sweep_info = self.extract_sweep_stim_info()
 
-        self.build_sweep_table(sweep_info)
-
-    @property
-    def nwb_data(self):
-        return self._nwb_data
+        self.build_sweep_table(sweep_info, deprecation_warning=False)
 
 
     def extract_sweep_stim_info(self):
@@ -39,12 +46,12 @@ class HBGDataSet(EphysDataSet):
 
             return value
 
-        for index, sweep_map in self.nwb_data.sweep_map_table.iterrows():
+        for index, sweep_map in self._nwb_data.sweep_map_table.iterrows():
             sweep_record = {}
             sweep_num = sweep_map["sweep_number"]
             sweep_record["sweep_number"] = sweep_num
 
-            attrs = self.nwb_data.get_sweep_attrs(sweep_num)
+            attrs = self._nwb_data.get_sweep_attrs(sweep_num)
 
             sweep_record["stimulus_units"] = self.get_stimulus_units(sweep_num)
 
@@ -64,12 +71,12 @@ class HBGDataSet(EphysDataSet):
 
     def get_stimulus_units(self, sweep_num):
 
-        unit_str = self.nwb_data.get_stimulus_unit(sweep_num)
+        unit_str = self._nwb_data.get_stimulus_unit(sweep_num)
         return unit_str
 
     def get_clamp_mode(self, sweep_num):
 
-        attrs = self.nwb_data.get_sweep_attrs(sweep_num)
+        attrs = self._nwb_data.get_sweep_attrs(sweep_num)
         timeSeriesType = attrs["neurodata_type"]
 
         if "CurrentClamp" in timeSeriesType:
@@ -83,13 +90,13 @@ class HBGDataSet(EphysDataSet):
 
     def get_stimulus_code(self, sweep_num):
 
-        stim_code_ext = self.nwb_data.get_stim_code(sweep_num)
+        stim_code_ext = self._nwb_data.get_stim_code(sweep_num)
 
         return stim_code_ext.split("[")[0]
 
     def get_stimulus_code_ext(self, sweep_num):
 
-        return self.nwb_data.get_stim_code(sweep_num)
+        return self._nwb_data.get_stim_code(sweep_num)
 
     def get_recording_date(self):
-        return self.nwb_data.get_recording_date()
+        return self._nwb_data.get_recording_date()

--- a/ipfx/nwb_reader.py
+++ b/ipfx/nwb_reader.py
@@ -116,9 +116,9 @@ class NwbReader(object):
     def get_long_unit_name(unit):
         if not unit:
             return "Unknown"
-        if unit.startswith('A'):
+        if unit[0] in {"a", "A"}:
             return "Amps"
-        elif unit.startswith('V'):
+        elif unit[0] in {"v", "V"}:
             return "Volts"
         else:
             return unit
@@ -126,7 +126,7 @@ class NwbReader(object):
     @staticmethod
     def validate_SI_unit(unit):
 
-        valid_SI_units = ["Volts", "Amps"]
+        valid_SI_units = {"Volts", "Amps"}
         if unit not in valid_SI_units:
             raise ValueError(F"Unit {unit} is not among the valid SI units {valid_SI_units}")
 

--- a/ipfx/x_to_nwb/NWBConverter.py
+++ b/ipfx/x_to_nwb/NWBConverter.py
@@ -7,6 +7,8 @@ import logging
 
 import numpy as np
 
+from allensdk.deprecated import class_deprecated
+
 from pynwb import NWBHDF5IO, NWBFile
 from pynwb.icephys import CurrentClampStimulusSeries, VoltageClampStimulusSeries
 from pynwb.icephys import CurrentClampSeries, VoltageClampSeries
@@ -20,6 +22,10 @@ import ipfx.nwb_reader as nwb_reader
 log = logging.getLogger(__name__)
 
 
+@class_deprecated(
+    "Starting from ipfx 1.0.0, NWB1 will no longer be supported. Instead, "
+    "NWB2 will be supported. NWBConverter will be removed."
+)
 class NWBConverter:
 
     V_CLAMP_MODE = "voltage_clamp"

--- a/tests/test_ephys_data_set.py
+++ b/tests/test_ephys_data_set.py
@@ -37,7 +37,7 @@ def get_empty_dataset():
 
     default_ontology = StimulusOntology(ju.read(StimulusOntology.DEFAULT_STIMULUS_ONTOLOGY_FILE))
     dataset = EphysDataSet(default_ontology)
-    dataset.build_sweep_table(sweep_info=[])
+    dataset.build_sweep_table(sweep_info=[], deprecation_warning=False)
 
     return dataset
 
@@ -105,27 +105,6 @@ def test_get_sweep_record():
     compare_dicts(expected, actual)
 
 
-def test_sweep_raises():
-
-    with pytest.raises(NotImplementedError):
-        ds = get_dataset()
-        ds.sweep(5)
-
-
-def test_set_sweep_raises_int():
-
-    with pytest.raises(NotImplementedError):
-        ds = get_dataset()
-        ds.sweep_set(5)
-
-
-def test_set_sweep_raises_list():
-
-    with pytest.raises(NotImplementedError):
-        ds = get_dataset()
-        ds.sweep_set([5, 6])
-
-
 def test_aligned_sweeps_raises():
     with pytest.raises(NotImplementedError):
         ds = get_dataset()
@@ -140,13 +119,6 @@ def test_get_clamp_mode_raises():
     with pytest.raises(NotImplementedError):
         ds = get_dataset()
         ds.get_clamp_mode(0)
-
-def test_extract_sweep_stim_info_raises():
-    with pytest.raises(NotImplementedError):
-        ds = get_dataset()
-        ds.extract_sweep_stim_info()
-
-
 
 
 def test_get_stimulus_name():
@@ -167,10 +139,3 @@ def test_get_stimulus_name_works():
 
     expected = {EphysDataSet.STIMULUS_CODE: stimulus_code, EphysDataSet.STIMULUS_NAME: "Test"}
     assert expected == d
-
-
-def test_get_sweep_data():
-
-    with pytest.raises(NotImplementedError):
-        ds = get_dataset()
-        ds.get_sweep_data(123)

--- a/tests/test_nwb1_nwb2_conversion.py
+++ b/tests/test_nwb1_nwb2_conversion.py
@@ -84,7 +84,7 @@ def test_stimulus_round_trip(nwb_filename):
     data = np.array([1., 3.76, 0., 67, -2.89])
     meta_data = {"name":"test_stimulus_sweep",
                  "sweep_number": 4,
-                 "unit": "A",
+                 "unit": "amperes",
                  "gain": 32.0,
                  "resolution": 1.0,
                  "conversion": 1.0E-3,
@@ -128,7 +128,7 @@ def test_acquisition_round_trip(nwb_filename):
     data = np.array([1., 3.76, 0., 67, -2.89])
     meta_data = {"name":"test_acquisition_sweep",
                  "sweep_number": 4,
-                 "unit": "V",
+                 "unit": "volts",
                  "gain": 32.0,
                  "resolution": 1.0,
                  "conversion": 1.0E-3,


### PR DESCRIPTION
adds warnings and a readme message warning that we are dropping python2 and nwb1 support.

Also makes the nwbreader compatible with "amperes" and "volts" as units.

A note: There are a bunch of dataset tests that just assert notimplemented errors are raised. I moved a method to ephysdataset, which broke some, so I deleted them. I did this because:
1. they don't really test anything
2. we are replacing these tests anyways

If you disagree with this approach, lemme know. Another way would be to add more errors to the pytest raises statements.