### PR TITLE
BF(BK): do not pin hdmf and pynwb, only provide minimal compatible versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,9 +8,9 @@ pillow
 argschema
 allensdk
 dictdiffer
-hdmf==1.1.2
+hdmf>=1.1.2
 pyabf<2.3.0
-pynwb==1.0.2
+pynwb>=1.0.2
 six
 watchdog
 pg8000


### PR DESCRIPTION
This is a similar request to
https://github.com/AllenInstitute/AllenSDK/pull/1326
and please see
https://github.com/AllenInstitute/AllenSDK/issues/1325
for rationale, and pointed there
https://github.com/NeurodataWithoutBorders/pynwb/issues/1133#issuecomment-571764474

I consider it a "bug fix" (BF) since such hard pining (at the install_requires
level) prevents co-installation of this module and any other module requiring
different version of pynwb.  It would actually be ok to pin in requirements.txt but setup.py then must be adjusted to convert `==` into `>=` or alike. ATM it just passes them as is. See e.g. what pynwb does now: https://github.com/NeurodataWithoutBorders/pynwb/blob/dev/setup.py#L15

I also marked it as BK since most likely it would break tests.