### PR TITLE
manually set "modified" on nwb containers in attach_metadata

### DIFF
--- a/ipfx/attach_metadata/sink/nwb2_sink.py
+++ b/ipfx/attach_metadata/sink/nwb2_sink.py
@@ -85,6 +85,7 @@ class Nwb2Sink(MetadataSink):
         """
 
         set_container_sources(self.nwbfile, self._h5_file.filename)
+        self.nwbfile.set_modified(True)
         self._nwb_io.write(self.nwbfile)
         self._nwb_io.close()
         self._h5_file.close()
@@ -111,7 +112,10 @@ class Nwb2Sink(MetadataSink):
                 f"{len(keys)}"
             )
 
-        return self.nwbfile.icephys_electrodes[keys[0]]
+        electrode = self.nwbfile.icephys_electrodes[keys[0]]
+        electrode.set_modified(True)
+
+        return electrode
     
     def _get_sweep_series(
             self, 
@@ -140,6 +144,7 @@ class Nwb2Sink(MetadataSink):
         """
         if self.nwbfile.subject is None:
             self.nwbfile.subject = pynwb.file.Subject()
+        self.nwbfile.subject.set_modified(True)
         return self.nwbfile.subject
 
     def register(self, name: str, value: Any, sweep_id: Optional[int] = None):

--- a/tests/attach_metadata/test_nwb2_sink.py
+++ b/tests/attach_metadata/test_nwb2_sink.py
@@ -113,6 +113,23 @@ def test_serialize(tmpdir_factory, nwbfile):
         obt = reader.read()
         assert obt.identifier == "test session"
 
+
+def test_roundtrip(tmpdir_factory, nwbfile):
+    tmpdir = str(tmpdir_factory.mktemp("test_serialize"))
+    first_path = os.path.join(tmpdir, "first.nwb")
+    second_path = os.path.join(tmpdir, "second.nwb")
+
+    with pynwb.NWBHDF5IO(first_path, "w") as writer:
+        writer.write(nwbfile)
+
+    sink = nwb2_sink.Nwb2Sink(first_path)
+    sink.register("institution", "AIBS")
+    sink.serialize({"output_path": second_path})
+
+    with pynwb.NWBHDF5IO(second_path, "r") as reader:
+        obt = reader.read()
+        assert obt.institution == "AIBS"
+
 @pytest.mark.parametrize("name, value, sweep_id, getter, expected", [
     ["subject_id", "mouse01", None, lambda f: f.subject.subject_id, "mouse01"],
     ["institution", "aibs", None, lambda f: f.institution, "aibs"]


### PR DESCRIPTION
Otherwise they get skipped