### PR TITLE
passes cache_spec=False to nwb_io.write() to avoid spec writer shape …

### DIFF
--- a/ipfx/attach_metadata/sink/nwb2_sink.py
+++ b/ipfx/attach_metadata/sink/nwb2_sink.py
@@ -86,7 +86,7 @@ class Nwb2Sink(MetadataSink):
 
         set_container_sources(self.nwbfile, self._h5_file.filename)
         self.nwbfile.set_modified(True)
-        self._nwb_io.write(self.nwbfile)
+        self._nwb_io.write(self.nwbfile, cache_spec=False)
         self._nwb_io.close()
         self._h5_file.close()
 

--- a/ipfx/nwb_append.py
+++ b/ipfx/nwb_append.py
@@ -61,5 +61,5 @@ def append_spike_times(input_nwb_path: PathLike,
 
     nwbfile.add_processing_module(spike_module)
 
-    nwb_io.write(nwbfile)
+    nwb_io.write(nwbfile, cache_spec=False)
     nwb_io.close()


### PR DESCRIPTION
Resolve #404 …error