### PR TITLE
#408 update ipfx nwb reading to handle in-file namespaces. Update tests

### DIFF
--- a/ipfx/attach_metadata/sink/nwb2_sink.py
+++ b/ipfx/attach_metadata/sink/nwb2_sink.py
@@ -74,7 +74,8 @@ class Nwb2Sink(MetadataSink):
         self._nwb_io = pynwb.NWBHDF5IO(
             path=self._h5_file.filename,
             mode="r+",
-            file=self._h5_file
+            file=self._h5_file,
+            load_namespaces=True
         )
         self.nwbfile = self._nwb_io.read()
 

--- a/ipfx/bin/nwb_to_pdf.py
+++ b/ipfx/bin/nwb_to_pdf.py
@@ -227,7 +227,7 @@ def gather_sweeps(nwbfile):
     sort PatchClampSeries according to cycle_id
     '''
     sweeps = SweepCollection()
-    with NWBHDF5IO(nwbfile, 'r') as io:
+    with NWBHDF5IO(nwbfile, 'r', load_namespaces=True) as io:
         nwb = io.read()
         for key in nwb.acquisition:
             acquisition = nwb.get_acquisition(key)
@@ -297,7 +297,7 @@ def check_stimset_reconstruction(nwbfile, outfile):
     plt.rcParams['axes.grid'] = True
     box_props = {"boxstyle": 'round', "facecolor": 'wheat', "alpha": 0.5}
 
-    with NWBHDF5IO(nwbfile, 'r') as io:
+    with NWBHDF5IO(nwbfile, 'r', load_namespaces=True) as io:
         nwb = io.read()
 
         with PdfPages(outfile) as pdf:

--- a/ipfx/dataset/ephys_nwb_data.py
+++ b/ipfx/dataset/ephys_nwb_data.py
@@ -84,12 +84,12 @@ class EphysNWBData(EphysDataInterface):
                 with open(nwb_file, 'rb') as fh:
                     data = BytesIO(fh.read())
                 _h5_file = h5py.File(data, "r")
-                reader = NWBHDF5IO(path=_h5_file.filename, mode="r",file=_h5_file)
+                reader = NWBHDF5IO(path=_h5_file.filename, mode="r",file=_h5_file, load_namespaces=True)
             else:
-                reader = NWBHDF5IO(nwb_file, mode='r')
+                reader = NWBHDF5IO(nwb_file, mode='r', load_namespaces=True)
         elif isinstance(nwb_file, BytesIO):
             _h5_file = h5py.File(nwb_file, "r")
-            reader = NWBHDF5IO(path=_h5_file.filename, mode="r",file=_h5_file)
+            reader = NWBHDF5IO(path=_h5_file.filename, mode="r",file=_h5_file, load_namespaces=True)
         else:
             raise TypeError("Invalid input NWB file (only accept NWB filepath or hdf5 obj)!")
 

--- a/ipfx/nwb_append.py
+++ b/ipfx/nwb_append.py
@@ -44,7 +44,7 @@ def append_spike_times(input_nwb_path: PathLike,
     else:
         nwb_path = input_nwb_path
 
-    nwb_io = pynwb.NWBHDF5IO(nwb_path, mode='a')
+    nwb_io = pynwb.NWBHDF5IO(nwb_path, mode='a', load_namespaces=True)
     nwbfile = nwb_io.read()
 
     # Create spike module

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,10 +9,8 @@ argschema
 allensdk
 dictdiffer
 pyabf<2.3.0
-# hdmf>=1.6.1,<2.0.0
-git+https://github.com/hdmf-dev/hdmf@dev
-# pynwb>=1.3.0,<2.0.0
-git+https://github.com/nilegraddis/pynwb@file-obj-namespaces
+hdmf>=1.6.2,<2.0.0
+pynwb>=1.3.1,<2.0.0
 watchdog
 pg8000
 pyYAML<6.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,8 +9,10 @@ argschema
 allensdk
 dictdiffer
 pyabf<2.3.0
-hdmf>=1.6.1,<2.0.0
-pynwb>=1.3.0,<2.0.0
+# hdmf>=1.6.1,<2.0.0
+git+https://github.com/hdmf-dev/hdmf@dev
+# pynwb>=1.3.0,<2.0.0
+git+https://github.com/nilegraddis/pynwb@file-obj-namespaces
 watchdog
 pg8000
 pyYAML<6.0.0

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,6 @@ from setuptools import setup, find_packages
 
 with open("requirements.txt", "r") as requirements_file:
     required = requirements_file.read().splitlines()
-    required = [req for req in required if not "git+" in req] # TODO remove this pending hdmf, pynwb releases
 
 version_file_path = os.path.join(
     os.path.dirname(__file__),

--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,7 @@ from setuptools import setup, find_packages
 
 with open("requirements.txt", "r") as requirements_file:
     required = requirements_file.read().splitlines()
+    required = [req for req in required if not "git+" in req] # TODO remove this pending hdmf, pynwb releases
 
 version_file_path = os.path.join(
     os.path.dirname(__file__),

--- a/tests/attach_metadata/test_nwb2_sink.py
+++ b/tests/attach_metadata/test_nwb2_sink.py
@@ -109,7 +109,7 @@ def test_serialize(tmpdir_factory, nwbfile):
 
     sink.serialize({"output_path": out_path})
 
-    with pynwb.NWBHDF5IO(out_path, "r") as reader:
+    with pynwb.NWBHDF5IO(out_path, "r", load_namespaces=True) as reader:
         obt = reader.read()
         assert obt.identifier == "test session"
 
@@ -126,7 +126,7 @@ def test_roundtrip(tmpdir_factory, nwbfile):
     sink.register("institution", "AIBS")
     sink.serialize({"output_path": second_path})
 
-    with pynwb.NWBHDF5IO(second_path, "r") as reader:
+    with pynwb.NWBHDF5IO(second_path, "r", load_namespaces=True) as reader:
         obt = reader.read()
         assert obt.institution == "AIBS"
 

--- a/tests/data/nwb/Ctgf-T2A-dgCre;Ai14-495723.05.02.01-compressed-V2.nwb
+++ b/tests/data/nwb/Ctgf-T2A-dgCre;Ai14-495723.05.02.01-compressed-V2.nwb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ed8c8ed0af8cdd140efb142ff6f32f11665b40fa1ec3dd652c2cd6740b82289a
-size 21877490

--- a/tests/data/nwb/Ctgf-T2A-dgCre;Ai14-495723.05.02.01.nwb
+++ b/tests/data/nwb/Ctgf-T2A-dgCre;Ai14-495723.05.02.01.nwb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:97ed8f9f2dc21bd78d610b9e6a65711583e6c7b0d015b48e85960ccf2996c80f
+size 21911595

--- a/tests/data/nwb/Pvalb-IRES-Cre;Ai14(IVSCC)-165172.05.02-compressed-V2.nwb
+++ b/tests/data/nwb/Pvalb-IRES-Cre;Ai14(IVSCC)-165172.05.02-compressed-V2.nwb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:69cd2ed3611998705fe819b97ff6adb03f7c12d0e6a8face149f13ba6d7e4387
-size 170150361

--- a/tests/data/nwb/Pvalb-IRES-Cre;Ai14(IVSCC)-165172.05.02.nwb
+++ b/tests/data/nwb/Pvalb-IRES-Cre;Ai14(IVSCC)-165172.05.02.nwb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:81f70c15895d3799528eb7d4399b8729ae374053fe6b63ced30750a59f9c198f
+size 170205188

--- a/tests/data/nwb/Vip-IRES-Cre;Ai14-331294.04.01.01-compressed-V2.nwb
+++ b/tests/data/nwb/Vip-IRES-Cre;Ai14-331294.04.01.01-compressed-V2.nwb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:5d9dcb918bdfb60a79062890a3b77a58b26b83ca27aef473747c4daf377825d6
-size 17332553

--- a/tests/data/nwb/Vip-IRES-Cre;Ai14-331294.04.01.01.nwb
+++ b/tests/data/nwb/Vip-IRES-Cre;Ai14-331294.04.01.01.nwb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9b8a4d4f34ce0a5185fbc6bdeea80267957816b2718ae37377b03aafcbf7c269
+size 17370065

--- a/tests/data/specimens/Ctgf-T2A-dgCre;Ai14-495723.05.02.01/pipeline_input.json
+++ b/tests/data/specimens/Ctgf-T2A-dgCre;Ai14-495723.05.02.01/pipeline_input.json
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:da35cc60a287edbc0c251fa372353a8f818910ff80ebe95de57496465f5d5c7b
-size 966
+oid sha256:6394ea201f82a2506ffab183abe03cad0f0c11bbe3cda06ad4a62be778ee636b
+size 952

--- a/tests/data/specimens/Pvalb-IRES-Cre;Ai14(IVSCC)-165172.05.02/pipeline_input.json
+++ b/tests/data/specimens/Pvalb-IRES-Cre;Ai14(IVSCC)-165172.05.02/pipeline_input.json
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:44388f0c2ceb451bf35a5dd4926216c2d80c07fa851934d106321d38e7687ee7
-size 974
+oid sha256:eaa4a6cbba662841603104ac69d62aa6e095f4f96d8792395d937ee296402f42
+size 960

--- a/tests/data/specimens/Vip-IRES-Cre;Ai14-331294.04.01.01/pipeline_input.json
+++ b/tests/data/specimens/Vip-IRES-Cre;Ai14-331294.04.01.01/pipeline_input.json
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ffe25ad97e7764cccea1219a27b11cf926d21b92f2d1cccb26411b9d3ae3dfca
-size 962
+oid sha256:cc4e2150dff27473cf1a0abea96c58b67deea60148fd630a8ba5903eb2e41aa0
+size 948

--- a/tests/helpers_for_tests.py
+++ b/tests/helpers_for_tests.py
@@ -113,7 +113,7 @@ def validate_nwb(filename):
     """
 
     if os.path.exists(filename):
-        with NWBHDF5IO(filename, mode='r') as io:
+        with NWBHDF5IO(filename, mode='r', load_namespaces=True) as io:
             try:
                 errors = validate(io)
             except Exception as e:

--- a/tests/test_append_nwb.py
+++ b/tests/test_append_nwb.py
@@ -44,7 +44,7 @@ def test_embed_spike_times_into_nwb(tmpdir_factory):
                        sweep_spike_times,
                        output_nwb_path=output_nwb_file_name)
 
-    with pynwb.NWBHDF5IO(output_nwb_file_name, mode='r') as nwb_io:
+    with pynwb.NWBHDF5IO(output_nwb_file_name, mode='r', load_namespaces=True) as nwb_io:
         nwbfile = nwb_io.read()
 
         spikes = nwbfile.get_processing_module('spikes')

--- a/tests/test_mies_nwb_pipeline_output.py
+++ b/tests/test_mies_nwb_pipeline_output.py
@@ -80,6 +80,15 @@ def test_mies_nwb_pipeline_output(input_json, output_json, tmpdir_factory):
     expected = ju.read(output_json)
 
     output_diff = list(diff(expected, obtained, tolerance=0.001))
-    if output_diff:
-        print(output_diff)
-    assert len(output_diff) == 0
+
+    # There is a known issue with newer MIES-generated NWBs: They report 
+    # recording date in offsetless UTC, rather than local time +- an offset to 
+    # UTC as in the older generation.
+    unacceptable = []
+    for item in output_diff:
+        if not "recording_date" in item[1]:
+            unacceptable.append(item)      
+
+    if unacceptable:
+        print(unacceptable)
+    assert len(unacceptable) == 0


### PR DESCRIPTION
Load namespaces from NWB files when provided. Makes various supporting changes, such as updating tests & their data. This handles cutting-edge MIES NWBs

In order to be fully done with this PR, we need:
- new releases of pynwb and hdmf
- to remove the patch in requirements.txt pointing at in-development branches of those packages.

In the meantime, you can use these changes by installing the requirements via `pip insatll -r requirements.txt`. I have prepared a conda environment at /allen/aibs/informatics/nileg/ipfx_june/test_env/ with this branch installed.