### PR TITLE
GH-1594 (allensdk) additional nwb metadata

### DIFF
--- a/ipfx/attach_metadata/sink/nwb2_sink.py
+++ b/ipfx/attach_metadata/sink/nwb2_sink.py
@@ -37,6 +37,12 @@ class Nwb2Sink(MetadataSink):
             "institution",
             "electrode_id",
             "electrode_resistance",
+            "session_id",
+            "age",
+            "genotype",
+            "sex",
+            "species",
+            "date_of_birth"
         }
 
     @property
@@ -176,6 +182,18 @@ class Nwb2Sink(MetadataSink):
                 self._get_single_ic_electrode().name = str(value)
             elif name == "electrode_resistance":
                 self._get_single_ic_electrode().resistance = value
+            elif name == "session_id":
+                self.nwbfile.session_id = value
+            elif name == "age":
+                self._get_subject().age = value
+            elif name == "genotype":
+                self._get_subject().genotype = value
+            elif name == "sex":
+                self._get_subject().sex = value
+            elif name == "species":
+                self._get_subject().species = value
+            elif name == "date_of_birth":
+                self._get_subject().date_of_birth = value
             else:
                 self._cant_attach(name, sweep_id)
 

--- a/tests/attach_metadata/test_nwb2_sink.py
+++ b/tests/attach_metadata/test_nwb2_sink.py
@@ -132,7 +132,13 @@ def test_roundtrip(tmpdir_factory, nwbfile):
 
 @pytest.mark.parametrize("name, value, sweep_id, getter, expected", [
     ["subject_id", "mouse01", None, lambda f: f.subject.subject_id, "mouse01"],
-    ["institution", "aibs", None, lambda f: f.institution, "aibs"]
+    ["institution", "aibs", None, lambda f: f.institution, "aibs"],
+    ["session_id", "12345", None, lambda f: f.session_id, "12345"],
+    ["age", "P56D", None, lambda f: f.subject.age, "P56D"],
+    ["date_of_birth", "2019-05-12 17:00:00 -0700", None, lambda f: f.subject.date_of_birth, "2019-05-12 17:00:00 -0700"],
+    ["genotype", "Gad2-IRES-Cre/wt;Ai14(RCL-tdT)/wt", None, lambda f: f.subject.genotype, "Gad2-IRES-Cre/wt;Ai14(RCL-tdT)/wt"],
+    ["sex", "F", None, lambda f: f.subject.sex, "F"],
+    ["species", "Mus musculus", None, lambda f: f.subject.species, "Mus musculus"]
 ])
 def test_register(nwbfile, name, value, sweep_id, getter, expected):
 


### PR DESCRIPTION
Adds support for writing additional fields to NWB2 sinks when attaching metadata.