### PR TITLE
fix apidoc section rendering

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -62,7 +62,8 @@ extensions = ['sphinx.ext.autodoc',
               'sphinx.ext.viewcode',
               'sphinx.ext.mathjax',
               'sphinx_gallery.gen_gallery',
-              'm2r']
+              'm2r',
+              'numpydoc']
 
 sphinx_gallery_conf = {
     # path to your examples scripts

--- a/requirements_docs.txt
+++ b/requirements_docs.txt
@@ -1,3 +1,4 @@
 sphinx
 sphinx-gallery
 m2r
+numpydoc>=0.6.0,<1.0.0


### PR DESCRIPTION
adds numpydoc to sphinx extensions, allowing the "Parameters" section to render.