### PR TITLE
GH-426 Fix deprecation warning for ephys_data_set

### DIFF
--- a/docs/gallery/analysis_examples/ramp_analysis.py
+++ b/docs/gallery/analysis_examples/ramp_analysis.py
@@ -8,8 +8,6 @@ Calculate features of Ramp sweeps
 import os
 import matplotlib.pyplot as plt
 import seaborn as sns
-from allensdk.api.queries.cell_types_api import CellTypesApi
-from ipfx.data_set_utils import create_data_set
 from ipfx.epochs import get_stim_epoch
 from ipfx.dataset.create import create_ephys_data_set
 from ipfx.utilities import drop_failed_sweeps
@@ -20,7 +18,6 @@ from ipfx.feature_extractor import (
 from ipfx.stimulus_protocol_analysis import RampAnalysis
 
 # Download and access the experimental data
-ct = CellTypesApi()
 nwb_file = os.path.join(
     os.path.dirname(os.getcwd()),
     "data",

--- a/ipfx/data_set_features.py
+++ b/ipfx/data_set_features.py
@@ -36,7 +36,7 @@
 import numpy as np
 import logging
 from .feature_extractor import SpikeFeatureExtractor,SpikeTrainFeatureExtractor
-from . import ephys_data_set as eds
+from ipfx.dataset.ephys_data_set import EphysDataSet
 from . import spike_features as spkf
 from . import stimulus_protocol_analysis as spa
 from . import stim_features as stf
@@ -46,17 +46,10 @@ from . import logging_utils as lu
 
 DEFAULT_DETECTION_PARAMETERS = { 'dv_cutoff': 20.0, 'thresh_frac': 0.05 }
 
-# DETECTION_PARAMETERS = {
-#     eds.EphysDataSet.SHORT_SQUARE: { 'est_window': (1.02, 1.021), 'thresh_frac_floor': 0.1 },
-#     eds.EphysDataSet.SHORT_SQUARE_TRIPLE: { 'est_window': (2.02, 2.021), 'thresh_frac_floor': 0.1 },
-#     eds.EphysDataSet.RAMP: { 'start': 1.02 },
-#     eds.EphysDataSet.LONG_SQUARE: { 'start': 1.02, 'end': 2.02 }
-# }
-
 DETECTION_PARAMETERS = {
-    eds.EphysDataSet.SHORT_SQUARE: {'thresh_frac_floor': 0.1 },
-    eds.EphysDataSet.RAMP: { },
-    eds.EphysDataSet.LONG_SQUARE: { }
+    EphysDataSet.SHORT_SQUARE: {'thresh_frac_floor': 0.1 },
+    EphysDataSet.RAMP: { },
+    EphysDataSet.LONG_SQUARE: { }
 }
 
 

--- a/ipfx/sweep_props.py
+++ b/ipfx/sweep_props.py
@@ -1,7 +1,7 @@
 import logging
 import re
 
-from .ephys_data_set import EphysDataSet
+from ipfx.dataset.ephys_data_set import EphysDataSet
 
 
 def override_auto_sweep_states(manual_sweep_states,sweep_states):


### PR DESCRIPTION
Change to import EphysDatSet from the dataset.ephys_data_set
to avoid the deprecation warning

Thank you for contributing to the IPFX, your work and time will help to
advance open science! 

# Overview:
Address #426 

# Type of Fix:
- [x] Bug fix (non-breaking change which fixes an issue)

# Solution:
import from the dataset.ephys_data_set

