### PR TITLE
suppresses ignoring namespace errors in NWBHDF5IO

### DIFF
--- a/ipfx/dataset/ephys_nwb_data.py
+++ b/ipfx/dataset/ephys_nwb_data.py
@@ -7,7 +7,7 @@ from dateutil import parser as dateparser
 
 from io import BytesIO
 import h5py
-from pynwb import NWBHDF5IO
+from pynwb import NWBHDF5IO as _NWBHDF5IO
 
 from pynwb.icephys import (
     CurrentClampSeries, CurrentClampStimulusSeries,
@@ -16,6 +16,16 @@ from pynwb.icephys import (
 
 from ipfx.stimulus import StimulusOntology
 from ipfx.dataset.ephys_data_interface import EphysDataInterface
+
+
+class NWBHDF5IO(_NWBHDF5IO):
+    """
+    Simple alias to suppress 'ignoring namespace' errors in NWBHDF5IO
+    """
+    def __init__(self, *args, **kwargs):
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", message="ignoring namespace*")
+            super().__init__(*args, **kwargs)
 
 
 def get_scalar_value(dataset_from_nwb):


### PR DESCRIPTION
# Overview:
Suppress "ignoring namespace '%s' because it already exists" errors when loading an ephys dataset from an NWB file


# Addresses:
Addresses issue [#425](https://github.com/AllenInstitute/ipfx/issues/425)

# Type of Fix:
<!--Chose One-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing
      functionality to not work as expected)
- [ ] Documentation Change

# Solution:
Alias NWBHDF5IO class with a context manger that suppresses the undesired warning