### PR TITLE
use python 3.6 throughout: test, deploy, docs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,7 +73,7 @@ jobs:
 
   deploy_pypi:
     docker:
-      - image: circleci/python:3.7
+      - image: circleci/python:3.6
     working_directory: ~/repo
 
     steps:

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -8,7 +8,7 @@ sphinx:
   builder: html
 
 python:
-   version: 3.7
+   version: 3.6
    install:
       - requirements: requirements_docs.txt
       - requirements: requirements.txt

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ class CheckVersionCommand(Command):
 
 
 setup(
-    name='ipfx',
+    name='IPFX',
     version=version,
     description="""Intrinsic Physiology Feature Extractor (IPFX) - tool for computing neuronal features from the intracellular electrophysiological recordings""",
     long_description=readme,
@@ -68,7 +68,7 @@ setup(
         "License :: Other/Proprietary License", # Allen Institute Software License
         "Natural Language :: English",
         "Operating System :: OS Independent",
-        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.6",
         "Topic :: Scientific/Engineering :: Bio-Informatics"
     ],
     cmdclass={'check_version': CheckVersionCommand}


### PR DESCRIPTION
The package is tested against python 3.6, so I guess we should stick to 3.6