### PR TITLE
Gh 444/use spikes if already exist

### DIFF
--- a/ipfx/_schemas.py
+++ b/ipfx/_schemas.py
@@ -108,7 +108,7 @@ class PipelineParameters(ArgSchema):
     )
     qc_criteria = Nested(QcCriteria, required=True)
     manual_sweep_states = Nested(ManualSweepState, required=False, many=True)
-
+    write_spikes = Boolean(description="Flag for writing spike times", required=False)
 
 class OutputSchema(DefaultSchema):
     input_parameters = Nested(FeatureExtractionParameters,

--- a/ipfx/bin/run_feature_extraction.py
+++ b/ipfx/bin/run_feature_extraction.py
@@ -5,7 +5,7 @@ import ipfx.error as er
 import ipfx.data_set_features as dsft
 from ipfx.stimulus import StimulusOntology
 from ipfx._schemas import FeatureExtractionParameters
-from ipfx.data_set_utils import create_data_set
+from ipfx.dataset.create import create_ephys_data_set
 import ipfx.sweep_props as sp
 import allensdk.core.json_utilities as ju
 from ipfx.nwb_append import append_spike_times
@@ -45,9 +45,9 @@ def run_feature_extraction(input_nwb_file,
         logging.info(F"Ontology is not provided, using default {StimulusOntology.DEFAULT_STIMULUS_ONTOLOGY_FILE}")
     ont = StimulusOntology(ju.read(stimulus_ontology_file))
 
-    data_set = create_data_set(sweep_info=sweep_info,
-                               nwb_file=input_nwb_file,
-                               ontology=ont)
+    data_set = create_ephys_data_set(sweep_info=sweep_info,
+                                     nwb_file=input_nwb_file,
+                                     ontology=ont)
 
     try:
         cell_features, sweep_features, cell_record, sweep_records = dsft.extract_data_set_features(data_set)

--- a/ipfx/bin/run_feature_extraction.py
+++ b/ipfx/bin/run_feature_extraction.py
@@ -31,7 +31,8 @@ def run_feature_extraction(input_nwb_file,
                            output_nwb_file,
                            qc_fig_dir,
                            sweep_info,
-                           cell_info):
+                           cell_info,
+                           write_spikes=True):
 
     lu.log_pretty_header("Extract ephys features", level=1)
 
@@ -69,9 +70,10 @@ def run_feature_extraction(input_nwb_file,
 
     if not cell_state["failed_fx"]:
         sweep_spike_times = collect_spike_times(sweep_features)
-        append_spike_times(input_nwb_file,
-                           sweep_spike_times,
-                           output_nwb_path=output_nwb_file)
+        if write_spikes:
+            append_spike_times(input_nwb_file,
+                               sweep_spike_times,
+                               output_nwb_path=output_nwb_file)
 
         if qc_fig_dir is None:
             logging.info("qc_fig_dir is not provided, will not save figures")

--- a/ipfx/bin/run_pipeline.py
+++ b/ipfx/bin/run_pipeline.py
@@ -18,7 +18,8 @@ def run_pipeline(
         stimulus_ontology_file,
         qc_fig_dir,
         qc_criteria,
-        manual_sweep_states
+        manual_sweep_states,
+        write_spikes=True,
 ):
 
     se_output = run_sweep_extraction(
@@ -57,7 +58,10 @@ def run_pipeline(
         qc_fig_dir,
         se_output['sweep_features'],
         se_output['cell_features'],
+        write_spikes,
     )
+
+    log_pretty_header("Analysis completed!", level=1)
 
     return {
         "sweep_extraction": se_output,
@@ -82,11 +86,11 @@ def main():
         module.args.get("stimulus_ontology_file", None),
         module.args.get("qc_fig_dir", None),
         module.args.get("qc_criteria", None),
-        module.args.get("manual_sweep_states", None)
+        module.args.get("manual_sweep_states", None),
+        module.args.get("write_spikes", None),
     )
 
     json_utilities.write(module.args["output_json"], output)
-    log_pretty_header("Analysis completed!", level=1)
 
 
 if __name__ == "__main__":

--- a/ipfx/bin/run_pipeline_from_nwb_file.py
+++ b/ipfx/bin/run_pipeline_from_nwb_file.py
@@ -20,6 +20,11 @@ def main():
     )
     parser.add_argument("input_nwb_file", type=str)
     parser.add_argument("output_dir", type=str)
+    parser.add_argument("--write_spikes",
+                        type=bool,
+                        default=False,
+                        help="If true will attempt to append spike times to the nwb file",
+                        )
     parser.add_argument("--input_json", type=str, default="input_json")
     parser.add_argument("--output_json", type=str, default="output_json")
 
@@ -50,7 +55,8 @@ def main():
                                    pipeline_input.get("stimulus_ontology_file", None),
                                    pipeline_input.get("qc_fig_dir", None),
                                    pipeline_input["qc_criteria"],
-                                   pipeline_input["manual_sweep_states"])
+                                   pipeline_input["manual_sweep_states"],
+                                   args["write_spikes"])
 
     ju.write(os.path.join(cell_dir, output_json), pipeline_output)
 

--- a/ipfx/bin/run_sweep_extraction.py
+++ b/ipfx/bin/run_sweep_extraction.py
@@ -4,7 +4,7 @@ import allensdk.core.json_utilities as json_utilities
 import argschema as ags
 
 from ipfx._schemas import SweepExtractionParameters
-from ipfx.data_set_utils import create_data_set
+from ipfx.dataset.create import create_ephys_data_set
 from ipfx.logging_utils import log_pretty_header
 from ipfx.bin.make_stimulus_ontology import make_stimulus_ontology_from_lims
 from ipfx.stimulus import StimulusOntology
@@ -56,7 +56,7 @@ def run_sweep_extraction(
         )
 
     ont = StimulusOntology(json_utilities.read(stimulus_ontology_file))
-    ds = create_data_set(
+    ds = create_ephys_data_set(
         nwb_file=input_nwb_file,
         ontology=ont
     )

--- a/ipfx/nwb_append.py
+++ b/ipfx/nwb_append.py
@@ -47,19 +47,26 @@ def append_spike_times(input_nwb_path: PathLike,
     nwb_io = pynwb.NWBHDF5IO(nwb_path, mode='a', load_namespaces=True)
     nwbfile = nwb_io.read()
 
-    # Create spike module
-    spike_module = ProcessingModule(name='spikes',
-                                    description='detected spikes')
-    for sweep_num, spike_times in sweep_spike_times.items():
-        wrapped_spike_times = H5DataIO(data=np.asarray(spike_times),
-                                       compression=True)
-        ts = TimeSeries(timestamps=wrapped_spike_times,
-                        unit='seconds',
-                        data=wrapped_spike_times,
-                        name=f"Sweep_{sweep_num}")
-        spike_module.add_data_interface(ts)
+    spikes_module = "spikes"
+    # Add spikes only if not previously added
+    if spikes_module not in nwbfile.processing.keys():
+        spike_module = ProcessingModule(name=spikes_module,
+                                        description='detected spikes')
+        for sweep_num, spike_times in sweep_spike_times.items():
+            wrapped_spike_times = H5DataIO(data=np.asarray(spike_times),
+                                           compression=True)
+            ts = TimeSeries(timestamps=wrapped_spike_times,
+                            unit='seconds',
+                            data=wrapped_spike_times,
+                            name=f"Sweep_{sweep_num}")
+            spike_module.add_data_interface(ts)
 
-    nwbfile.add_processing_module(spike_module)
+        nwbfile.add_processing_module(spike_module)
 
-    nwb_io.write(nwbfile)
+        nwb_io.write(nwbfile)
+    else:
+        raise ValueError("Cannot add spikes times to the nwb file: "
+                         "spikes times already exist!")
+
     nwb_io.close()
+


### PR DESCRIPTION
# Addresses:
Add an optional write_spikes with the default in the run_feature_extractor set to True
but in the run_from_nwb_file the default is set to False
this would avoid making changes to LIMS. Users processing dandi files would by default have write_spikes=False.

Addresses issue [#444]

# Type of Fix:
<!--Chose One-->
- [x] Bug fix (non-breaking change which fixes an issue)

# Solution:
Do not add spikes processing module if it already exists

