### PR TITLE
GH-454 run_pipeline_from_nwb_file is relative to cell output directory

### DIFF
--- a/docs/quick_start.rst
+++ b/docs/quick_start.rst
@@ -16,8 +16,8 @@ Input:
 
 Output:
 
- * pipeline_input.json: input parameters
- * pipeline_output.json: output including cell features
+ * input.json: input parameters
+ * output.json: output including cell features
  * output.nwb: NWB file including spike times
  * log.txt: run log
  * qc_figs: index.html includes cell figures and feature table and sweep.html includes sweep figures

--- a/ipfx/bin/generate_pipeline_input.py
+++ b/ipfx/bin/generate_pipeline_input.py
@@ -8,7 +8,8 @@ import ipfx.lims_queries as lq
 def generate_pipeline_input(cell_dir=None,
                             specimen_id=None,
                             input_nwb_file=None,
-                            plot_figures=False):
+                            plot_figures=False,
+                            qc_fig_dirname="qc_figs"):
 
     se_input = generate_se_input(cell_dir,
                                  specimen_id=specimen_id,
@@ -23,7 +24,7 @@ def generate_pipeline_input(cell_dir=None,
         pipe_input['manual_sweep_states'] = []
 
     if plot_figures:
-        pipe_input['qc_fig_dir'] = os.path.join(cell_dir,"qc_figs")
+        pipe_input['qc_fig_dir'] = os.path.join(cell_dir, qc_fig_dirname)
 
     pipe_input['output_nwb_file'] = os.path.join(cell_dir, "output.nwb")
     pipe_input['qc_criteria'] = ju.read(qcp.DEFAULT_QC_CRITERIA_FILE)

--- a/ipfx/bin/run_pipeline.py
+++ b/ipfx/bin/run_pipeline.py
@@ -19,7 +19,7 @@ def run_pipeline(
         qc_fig_dir,
         qc_criteria,
         manual_sweep_states,
-        write_spikes=True,
+        write_spikes=True
 ):
 
     se_output = run_sweep_extraction(

--- a/ipfx/bin/run_pipeline_from_nwb_file.py
+++ b/ipfx/bin/run_pipeline_from_nwb_file.py
@@ -29,7 +29,7 @@ def main():
         help="If true will attempt to append spike times to the nwb file",
     )
     parser.add_argument(
-        "--input_json", type=str, default="input_json",
+        "--input_json", type=str, default="input.json",
         help=(
             "write pipeline input json file here (relative to "
             "OUTPUT_DIR/cell_name, where cell_name is the extensionless "
@@ -37,7 +37,7 @@ def main():
         )
     )
     parser.add_argument(
-        "--output_json", type=str, default="output_json", 
+        "--output_json", type=str, default="output.json", 
         help=(
             "write output json file here (relative to OUTPUT_DIR/cell_name, "
             "where cell_name is the extensionless basename of the input NWB "
@@ -50,7 +50,8 @@ def main():
             "Generate qc figures and store them here (relative to "
             "OUTPUT_DIR/cell_name, where cell_name is the extensionless "
             "basename of the input nwb file). If you supply --qc_fig_dir with " 
-            "no arguments, the path will be OUTPUT_DIR/cell_name/qc_figs"
+            "no arguments, the path will be OUTPUT_DIR/cell_name/qc_figs. If "
+            "this argument is not supplied, no figures will be generated."
         )
     )
 


### PR DESCRIPTION
- run_pipeline_from_nwb_file's qc_fig_dir argument is now relative to cell_dir (can still specify an absolute path if you like)
- can argue --qc_fig_dir with build figures and store them in "qc_figs"
- adds documentation for run_pipeline_from_nwb_file's parameters

I had to choose between consistency with other executables and consistency with the other parameters of this executable. I went with the latter, but I'm not particularly wedded to the choice. Let me know in your review what you think