### PR TITLE
GH-471 Update pynwb requirements

### DIFF
--- a/docker/py36/Dockerfile
+++ b/docker/py36/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:3.6
+
+RUN apt-get update \
+    && apt-get install -y \
+        hdf5-tools \
+        curl
+
+RUN curl https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | bash
+
+RUN apt-get install git-lfs

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,8 +9,7 @@ argschema
 allensdk
 dictdiffer
 pyabf<2.3.0
-hdmf>=1.6.2,<2.0.0
-pynwb>=1.3.1,<2.0.0
+pynwb>=1.3.2,<2.0.0
 watchdog
 pg8000
 pyYAML<6.0.0


### PR DESCRIPTION
Addresses #471
- [x] Update version range of pynwb, drop hdmf requirement since it is installed as a dependency of pynwb
- [x] Build dedicated image for ipfx. 
- [x] Updated bamboo task to use the dedicated image both for Github and nightly build plans


Notes: 
1. I hosted in on the Docker Hub since I am not sure how to get the image on the aibs-artifactory.corp.alleninstitute.org. When Nick is back we can ask him how to upload the image to the artifactory.
2. This PR is against mastersince this is a hotfix. May be not so hot, but a fix anyway :)

Validation: 
the github branch CI on bamboo is passing! 