### PR TITLE
fix segment length rounding error #473 

### DIFF
--- a/ipfx/x_to_nwb/hr_segments.py
+++ b/ipfx/x_to_nwb/hr_segments.py
@@ -159,7 +159,11 @@ class Segment(ABC):
         """
         Return the number of points of this segment.
         """
-        return math.trunc(duration / self.sampleInterval)
+        num_points = duration / self.sampleInterval
+        num_points_int = int(np.round(num_points))
+        if not math.isclose(num_points, num_points_int):
+            raise ValueError(f"Segment duration {duration} is not divisible by sample interval {self.sampleInterval}")
+        return num_points_int
 
     def getAmplitude(self, channelRec, segmentRec):
         """


### PR DESCRIPTION
Addresses #473 
In the DAT converter, segments of sweeps are constructed with length calculated by floating point division. The result can be slightly less or greater than the the actual integer value, so applying math.trunc was dropping data points in some cases. This fixes the issue by rounding instead, and raises an error if the unrounded value is not close to an integer.