### PR TITLE
Prevent mismatch between number of values and labels in AP feature plots 

### DIFF
--- a/ipfx/plot_qc_figures.py
+++ b/ipfx/plot_qc_figures.py
@@ -84,18 +84,19 @@ def plot_single_ap_values(data_set, sweep_numbers, lims_features, sweep_features
 
     plt.figure(figs[0].number)
 
-    yvals = [float(lims_features[k + "_v_" + type_name]) for k in gen_features if lims_features[k + "_v_" + type_name] is not None]
+    yvals = [lims_features[k + "_v_" + type_name] for k in gen_features]
     xvals = range(len(yvals))
+    xticks = [k for k in gen_features]
 
     plt.scatter(xvals, yvals, color='blue', marker='_', s=40, zorder=100)
-    plt.xticks(xvals, ['thr', 'pk', 'tr', 'ftr', 'str'])
+    plt.xticks(xvals, xticks)
     plt.title(type_name + ": voltages")
 
     plt.figure(figs[1].number)
-    yvals = [float(lims_features[k + "_t_" + type_name]) for k in gen_features if lims_features[k + "_t_" + type_name] is not None]
+    yvals = [lims_features[k + "_t_" + type_name] for k in gen_features]
     xvals = range(len(yvals))
     plt.scatter(xvals, yvals, color='blue', marker='_', s=40, zorder=100)
-    plt.xticks(xvals, ['thr', 'pk', 'tr', 'ftr', 'str'])
+    plt.xticks(xvals, xticks)
     plt.title(type_name + ": times")
 
     plt.figure(figs[2].number)

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,8 +9,7 @@ argschema
 allensdk
 dictdiffer
 pyabf<2.3.0
-hdmf>=1.6.2,<2.0.0
-pynwb>=1.3.1,<2.0.0
+pynwb>=1.3.2,<2.0.0
 watchdog
 pg8000
 pyYAML<6.0.0


### PR DESCRIPTION
**Background:**
Sometimes AP feature value may be null. Previously these were treated as np.nan but at some point we changed np.nan to None that broke plotting.

This bug was discovered when validating http://jira.corp.alleninstitute.org/browse/PBS-2458 as a solution to #469 
The slow trough feature for the rheobase sweep is null for the nwb file in #469.

**Solution:**
allow None values into the plot which would silently omit the value from the plot as it did before the breaking change 
**Validation:**
should generating figures without errors:
`python -m ipfx.bin.run_pipeline_from_nwb_file /path/to/nwb2_H19.06.351.11.16.01.01.nwb /output/dir/ --qc_fig_dir
`