### PR TITLE
returns 0.0 for amplitude instead of nan

### DIFF
--- a/ipfx/qc_feature_extractor.py
+++ b/ipfx/qc_feature_extractor.py
@@ -307,6 +307,9 @@ def check_sweep_integrity(sweep, is_ramp):
             if sweep.epochs["recording"][1] < sweep.epochs["experiment"][1]:
                 tags.append("Recording stopped before completing the experiment epoch")
 
+    if np.isnan(sweep.i).any():
+        tags.append("Stimulus contains NaN values")
+
     return tags
 
 

--- a/ipfx/stim_features.py
+++ b/ipfx/stim_features.py
@@ -32,6 +32,9 @@ def get_stim_characteristics(i, t, test_pulse=True):
     else:
         amplitude = float(peak_low)
 
+    if np.isnan(amplitude):
+        amplitude = 0.0
+
     return start_time, duration, amplitude, start_idx, end_idx
 
 

--- a/ipfx/stim_features.py
+++ b/ipfx/stim_features.py
@@ -33,7 +33,7 @@ def get_stim_characteristics(i, t, test_pulse=True):
         amplitude = float(peak_low)
 
     if np.isnan(amplitude):
-        amplitude = 0.0
+        return None, None, 0.0, None, None
 
     return start_time, duration, amplitude, start_idx, end_idx
 


### PR DESCRIPTION
Bugfix, address #498 

Runs were failing because nan stimulus amplitudes converted to null when written to json, and LIMS EphysStimulus requires a numeric amplitude.