### PR TITLE
upgrades pip so cryptography wheel gets installed

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,6 +91,8 @@ jobs:
           command: |
             python3 -m venv venv
             . venv/bin/activate
+            pip install --upgrade pip
+            pip install -U cryptography
             pip install -U twine setuptools wheel
 
       - run:


### PR DESCRIPTION
Bugfix - circleci deploy_pypi job is failing due to no rust compiler found. Rust is needed to build cryptography from source, but updating pip and cryptography should grab a wheel instead, so no need for Rust.
