### PR TITLE
Fix missing electrode 0 when in bath sweep was ran with smoketest sti…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 All notable changes to this project will be documented in this file.
 
 ## Unreleased
+- Expands extract_electrode_0 function to try to determine if in-bath sweep was ran with smoke test stimulus wave if in-bath wave name was not found in stimulus ontology.
 
 ### Added
 

--- a/ipfx/qc_feature_extractor.py
+++ b/ipfx/qc_feature_extractor.py
@@ -92,13 +92,16 @@ def extract_electrode_0(data_set, tags):
     e0: float
     """
 
+    max_pipette_resistance = 0.0075 # 7.5 MOhms
     ontology = data_set.ontology
 
     try:
         bath_sweep_number = data_set.get_sweep_numbers(ontology.bath_names)[-1]
         bath_data = data_set.sweep(bath_sweep_number)
-
-        e0 = qcf.measure_electrode_0(bath_data.i, bath_data.sampling_rate)
+        seal = qcf.measure_seal(bath_data.i, bath_data.sampling_rate)
+        
+        if abs(seal) <= max_pipette_resistance:
+            e0 = qcf.measure_electrode_0(bath_data.i, bath_data.sampling_rate)
 
     except IndexError as e:  # ontology.bath_names did not find any bath sweeps
         try:
@@ -115,8 +118,8 @@ def extract_electrode_0(data_set, tags):
             for sweep in inbath_candidates:
                 bath_data = data_set.sweep(sweep)
                 seal = qcf.measure_seal(bath_data.v, bath_data.i, bath_data.t)
-                print(seal)
-                if abs(seal) < 0.01:
+                # print(seal)
+                if abs(seal) <= max_pipette_resistance:
                     e0 = qcf.measure_electrode_0(bath_data.i, bath_data.sampling_rate)
                     e0_candidates.append(e0)
 

--- a/ipfx/stimulus.py
+++ b/ipfx/stimulus.py
@@ -68,6 +68,7 @@ class StimulusOntology(object):
         self.seal_names = ( 'EXTPCllATT', )
         self.breakin_names = ( 'EXTPBREAKN', )
         self.extp_names = ( 'EXTP', )
+        self.smoketest_names = ( 'EXTPSMOKET', )
 
     def find(self, tag, tag_type=None):
         """

--- a/tests/test_extract_electrode_0.py
+++ b/tests/test_extract_electrode_0.py
@@ -1,0 +1,46 @@
+import pytest
+import os
+from ipfx.qc_feature_extractor import extract_electrode_0
+from ipfx.dataset.create import create_ephys_data_set
+
+def get_e0_tags(file_path, nwb_file, ont_file):
+    nwb_filename = os.path.join(file_path, nwb_file)
+    ont_filename = os.path.join(file_path, ont_file)
+
+    data_set = create_ephys_data_set(nwb_file=nwb_filename, ontology=ont_filename)
+
+    tags = []
+    e0 = extract_electrode_0(data_set, tags)
+    
+    return e0, tags
+
+
+def test_no_inbath_smoketest():
+    # This experiment does not contain an EXTPSMOKET sweep where pipette was in bath
+    file_path = "//allen/programs/celltypes/production/mousecelltypes/prod3053/Ephys_Roi_Result_1087546037/"
+    nwb_file = "Vip-IRES-Cre;Ai14-567749.01.10.02.nwb"
+    ont_file = "1087550462_stimulus_ontology.json"
+    
+    e0, tags = get_e0_tags(file_path, nwb_file, ont_file)
+    assert e0 is None
+    assert tags == ["Electrode 0 is not available"]
+
+def test_inbath_smoketest():
+    # This experiment does contain an EXTPSMOKET sweep where the pipette was in bath
+    file_path = "//allen/programs/celltypes/production/mousecelltypes/prod3050/Ephys_Roi_Result_1085978679/"
+    nwb_file = "Esr2-IRES2-Cre;Ai14-566833.04.10.02.nwb"
+    ont_file = "1085980322_stimulus_ontology.json"
+
+    e0, tags = get_e0_tags(file_path, nwb_file, ont_file)
+    assert e0 == pytest.approx(56.88125)
+    assert tags == []
+
+def test_inbath_multiple_smoketests():
+    # This experiment contains multiple EXTPSMOKET sweeps, but only 1 where pipette was in bath
+    file_path = "//allen/programs/celltypes/production/mousecelltypes/prod3008/Ephys_Roi_Result_1077512171/"
+    nwb_file = "Vipr2-IRES2-Cre;Slc32a1-IRES2-FlpO;Ai65-562071.12.09.04.nwb"
+    ont_file = "1077513177_stimulus_ontology.json"
+
+    e0, tags = get_e0_tags(file_path, nwb_file, ont_file)
+    assert e0 == pytest.approx(41.40625)
+    assert tags == []

--- a/tests/test_extract_electrode_0.py
+++ b/tests/test_extract_electrode_0.py
@@ -1,46 +1,28 @@
 import pytest
 import os
-from ipfx.qc_feature_extractor import extract_electrode_0
-from ipfx.dataset.create import create_ephys_data_set
-
-def get_e0_tags(file_path, nwb_file, ont_file):
-    nwb_filename = os.path.join(file_path, nwb_file)
-    ont_filename = os.path.join(file_path, ont_file)
-
-    data_set = create_ephys_data_set(nwb_file=nwb_filename, ontology=ont_filename)
-
-    tags = []
-    e0 = extract_electrode_0(data_set, tags)
-    
-    return e0, tags
+from ipfx.qc_feature_extractor import filter_smoketests, minimum_e0
 
 
-def test_no_inbath_smoketest():
-    # This experiment does not contain an EXTPSMOKET sweep where pipette was in bath
-    file_path = "//allen/programs/celltypes/production/mousecelltypes/prod3053/Ephys_Roi_Result_1087546037/"
-    nwb_file = "Vip-IRES-Cre;Ai14-567749.01.10.02.nwb"
-    ont_file = "1087550462_stimulus_ontology.json"
-    
-    e0, tags = get_e0_tags(file_path, nwb_file, ont_file)
-    assert e0 is None
-    assert tags == ["Electrode 0 is not available"]
+def test_filter_smoketests():
+    smoke_test_sweeps = [0,1,10]
+    cell_attached_sweep = 2
+    candidates = filter_smoketests(smoke_test_sweeps, cell_attached_sweep)
+    assert candidates == [0,1]
 
-def test_inbath_smoketest():
-    # This experiment does contain an EXTPSMOKET sweep where the pipette was in bath
-    file_path = "//allen/programs/celltypes/production/mousecelltypes/prod3050/Ephys_Roi_Result_1085978679/"
-    nwb_file = "Esr2-IRES2-Cre;Ai14-566833.04.10.02.nwb"
-    ont_file = "1085980322_stimulus_ontology.json"
 
-    e0, tags = get_e0_tags(file_path, nwb_file, ont_file)
-    assert e0 == pytest.approx(56.88125)
-    assert tags == []
+def test_minimum_e0_empty():
+    e0_candidates = []
+    min_e0 = minimum_e0(e0_candidates)
+    assert min_e0 == None
 
-def test_inbath_multiple_smoketests():
-    # This experiment contains multiple EXTPSMOKET sweeps, but only 1 where pipette was in bath
-    file_path = "//allen/programs/celltypes/production/mousecelltypes/prod3008/Ephys_Roi_Result_1077512171/"
-    nwb_file = "Vipr2-IRES2-Cre;Slc32a1-IRES2-FlpO;Ai65-562071.12.09.04.nwb"
-    ont_file = "1077513177_stimulus_ontology.json"
 
-    e0, tags = get_e0_tags(file_path, nwb_file, ont_file)
-    assert e0 == pytest.approx(41.40625)
-    assert tags == []
+def test_minimum_e0_negative():
+    e0_candidates = [-150, 50, -35, 120]
+    min_e0 = minimum_e0(e0_candidates)
+    assert min_e0 == -35
+
+
+def test_minimum_e0_positive():
+    e0_candidates = [-150, 50, -85, 120]
+    min_e0 = minimum_e0(e0_candidates)
+    assert min_e0 == 50


### PR DESCRIPTION
…mulus

This commit extends the 'extract_electrode_0' function and tries to
determine if the 'in-bath' sweep was ran with the 'EXTPSMOKET' stimulus
when the 'EXTPINBATH' stimulus is not found.

If 'EXTPINBATH' is not found then measure the seal of all 'EXTPSMOKET'
sweeps that occur before the first instance of 'EXTPCllATT' and only if
the resistance of the seal is below 10 MOhms then call
'measure_electrode_0'. Electrode 0 is not available if no 'EXTPSMOKET'
sweeps occurred before the first 'EXTPCllATT' sweep, the resistance is
above 10 MOhms, or if no 'EXTPSMOKET' or no 'EXTPCllATT' sweeps found.

Thank you for contributing to the IPFX, your work and time will help to
advance open science! 

# Overview:
Many of the recent IVSCC pipeline experiments are failing cell QC with fail tag
"electrode_0_pa missing value". This issue occurred because a software issue,
which has since been fixed, that was causing the in-bath sweep to be collected 
with the 'EXTPSMOKET' stimulus instead of the 'EXTPINBATH' stimulus. In fact,
these stimuli are the same wave, but with different names so that the stage 
of the experiment can be determined simply by the stimulus wave name. 
Most of these failing experiments actually contain the in bath sweep, but it 
was ran with the 'EXTPSMOKET' stimulus. IPFX needs to be able to look for 
in-bath sweeps collected with the 'EXTPSMOKET' stimulus when the 
'EXTPINBATH' stimulus is not found.


# Addresses:
Addresses issue [#509](https://github.com/AllenInstitute/ipfx/issues/509)


# Type of Fix:
- [x] New feature (non-breaking change which adds functionality)


# Solution:
When 'extract_electrode_0' does not find any 'EXTPINBATH' stimulus sweeps,
then it will look through any 'EXTPSMOKET' stimulus sweeps that occurr
before the first instance of the 'EXTPCllATT' sweep and check the resistance.
If the resistance is low, < 10 MOhms, then the pipette is determined to
have been in the bath and the 'measure_electrode_0' is called and the value
is returned. Electrode 0 is determined to be unavailable if no 'EXTPSMOKET'
sweeps occurred before the first 'EXTPCllATT' sweep, if no 'EXTPSMOKET'
sweeps have a resistance < 10 MOhms, or if no 'EXTPSMOKET', or no 
'EXTPCllATT' sweeps are present.


# Changes:
- Added self.smoketest_names to StimulusOntology to find 'EXTPSMOKET'
- Extended extract_electrode_0 function to try to get electrode 0 from 
   'EXTPSMOKET' stimulus sweeps when 'EXTPINBATH' is not found


# Validation:
I have tested this on the 600+ pipeline experiments that are affected by
this issue and have validated that it is only able to extract the electrode 0
from 'EXTPSMOKET' sweeps when the 'EXTPINBATH' is not found and 
if the resistance is <10 MOhms (the range of an open pipette in the bath).
I wrote some unit test that use experiments where the 'EXTPINBATH' is
missing and either:
- there is a 'EXTPSMOKET' sweep but the resistance is too high
- there are multiple 'EXTPSMOKET' sweeps, some occurring after
   'EXTPCllATT', but only one before the 'EXTPCllATT' sweep that has 
   a resistance < 10 MOhms 
- there are multiple 'EXTPSMOKET' sweeps, all occurring before the 
  'EXTPCllATT' sweep but only one with resistance < 10 MOhms


### Unit Tests:
A note about my unit tests: They are not hermetic as I needed data_sets
to test the extract_electrode_0 function so I am using nwb files from LIMS.
Please let me know if this is not acceptable and if there is an alternative
solution I could use.


# Notes:
Please let me know if there are any issues with my solution so that we
can address those ASAP. A lot of IVSCC pipeline data is being affected
by this issue and we are in need of a fix that will accomplish the 
functionality that I have added here. Thanks
