### PR TITLE
GH #508 - Remove np.nan values from np.diff array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,12 @@
 All notable changes to this project will be documented in this file.
 
 ## Unreleased
-
+This pull request adds a line of code to the get_stim_epoch function in epochs.py to 
+remove np.nan values from the array of differences between data points before removing 
+all non-zero values. This change allows get_stim_epoch to find the correct ending index 
+of the stimlus epoch and the correct ending index of the experiment epoch as well since
+it relys on the stimulus epoch, which should fix the issue of sweeps being incorrectly 
+tagged with "Recording stopped before completing the experiment epoch".
 ### Added
 
 ### Changed

--- a/ipfx/epochs.py
+++ b/ipfx/epochs.py
@@ -114,7 +114,8 @@ def get_stim_epoch(i, test_pulse=True):
     if test_pulse:
         di_idx = di_idx[2:]     # drop the first up/down (test pulse) if present
 
-    if len(di_idx) == 0:    # if no stimulus is found
+    # if no stimulus is found, len(di_idx=0), or end of stimulus is not found, len(di_idx=1)
+    if len(di_idx) < 2:    
         return None
 
     start_idx = di_idx[0] + 1   # shift by one to compensate for diff()

--- a/ipfx/epochs.py
+++ b/ipfx/epochs.py
@@ -108,6 +108,7 @@ def get_stim_epoch(i, test_pulse=True):
     """
 
     di = np.diff(i)
+    di = di[~np.isnan(di)] # != NaN
     di_idx = np.flatnonzero(di)   # != 0
 
     if test_pulse:

--- a/ipfx/qc_feature_extractor.py
+++ b/ipfx/qc_feature_extractor.py
@@ -307,7 +307,8 @@ def check_sweep_integrity(sweep, is_ramp):
             if sweep.epochs["recording"][1] < sweep.epochs["experiment"][1]:
                 tags.append("Recording stopped before completing the experiment epoch")
 
-    if np.isnan(sweep.i).any():
+    sweep_stim = sweep.i[sweep.epochs["stim"][0] : sweep.epochs["stim"][1]]
+    if np.isnan(sweep_stim).any():
         tags.append("Stimulus contains NaN values")
 
     return tags

--- a/ipfx/qc_feature_extractor.py
+++ b/ipfx/qc_feature_extractor.py
@@ -307,8 +307,12 @@ def check_sweep_integrity(sweep, is_ramp):
             if sweep.epochs["recording"][1] < sweep.epochs["experiment"][1]:
                 tags.append("Recording stopped before completing the experiment epoch")
 
-    sweep_stim = sweep.i[sweep.epochs["stim"][0] : sweep.epochs["stim"][1]]
-    if np.isnan(sweep_stim).any():
+    stim_start_idx = sweep.epochs['stim'][0]
+    stim_end_idx = sweep.epochs['stim'][1]
+    sweep_stim = sweep.i[stim_start_idx : stim_end_idx]
+    if stim_start_idx > stim_end_idx:
+        tags.append("Stimulus contains NaN values")
+    elif np.isnan(sweep_stim).any():
         tags.append("Stimulus contains NaN values")
 
     return tags

--- a/ipfx/qc_feature_extractor.py
+++ b/ipfx/qc_feature_extractor.py
@@ -307,14 +307,6 @@ def check_sweep_integrity(sweep, is_ramp):
             if sweep.epochs["recording"][1] < sweep.epochs["experiment"][1]:
                 tags.append("Recording stopped before completing the experiment epoch")
 
-    stim_start_idx = sweep.epochs['stim'][0]
-    stim_end_idx = sweep.epochs['stim'][1]
-    sweep_stim = sweep.i[stim_start_idx : stim_end_idx]
-    if stim_start_idx > stim_end_idx:
-        tags.append("Stimulus contains NaN values")
-    elif np.isnan(sweep_stim).any():
-        tags.append("Stimulus contains NaN values")
-
     return tags
 
 

--- a/tests/test_epochs.py
+++ b/tests/test_epochs.py
@@ -114,6 +114,11 @@ def test_get_test_epoch(i, sampling_rate, test_epoch):
                                  [0, 0, 1, 1, 0, 0, 2, 2, 2, 0, 0, np.nan, np.nan],
                                  (6, 8)
                              ),
+                             #   stim epoch has no ending index
+                             (
+                                 [0, 0, 1, 1, 0, 0, 2, 2, 2, np.nan, np.nan, np.nan], 
+                                 None
+                             )
 
                          ]
                          )

--- a/tests/test_epochs.py
+++ b/tests/test_epochs.py
@@ -109,6 +109,11 @@ def test_get_test_epoch(i, sampling_rate, test_epoch):
                                  [0, 0, 0, 0, 0, 0, 0],
                                  None
                              ),
+                             #   array containing np.nan
+                             (
+                                 [0, 0, 1, 1, 0, 0, 2, 2, 2, 0, 0, np.nan, np.nan],
+                                 (6, 8)
+                             ),
 
                          ]
                          )


### PR DESCRIPTION
# Overview:
np.nan values were not being dropped from the end of the np.diff array
before calling np.flatnonzero to remove non-zero values in get_stim_epoch.
This was causing get_stim_epoch to incorrectly identify the end of the
stimulus epoch as the same as the end of the sweep epoch, which was also
causing the end of the experiment epoch to be incorrect as well since it
relys on the stimulus epoch. By dropping the np.nan values from the end
of the difference array (di) in get_stim_epoch, the correct indices for
end of the stimulus epoch as well as for the experiment epoch are now being
returned. This should fix the issue with sweeps being incorrectly tagged
with 'Recording stopped before completing the experiment epoch'.


# Addresses:
Addresses issue https://github.com/AllenInstitute/ipfx/issues/508

# Type of Fix:
<!--Chose One-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing
      functionality to not work as expected)
- [ ] Documentation Change

# Solution:
After getting the differences from adjacent data points in the current trace (i)
with np.diff(), the resulting np.nan values are dropped from the end of the array
with ~np.isnan() before the non-zero points are removed with np.flatnonzero().
There are np.nan points at the end of the np.diff() array because there are np.nan
values at the end of the current trace (i), and the np.diff() function returns np.nan
for the difference between two np.nan points, and then these np.nan points get 
picked up along with the up/down indices of the stimulus and the index of the 
last np.nan value will be mistaken as the ending index of the stimulus epoch. 


# Changes:
Drop np.nan from di array in get_stim_epoch()
Updated test_get_stim_epoch() in test_epochs.py to test array containing np.nan
Updated Unreleased section of CHANGELOG.md


# Validation:
This looks like it was just missed in testing. An array containing np.nan
values was not tested in the original unit test. The solution was a pretty 
simple so the added unit test should be sufficient. 
*np.nan values can only occur at the end of a sweep so only the  ending 
index of the stimulus epoch was affected. 

### Screenshots:
See GH issue #508 for screenshots
### Unit Tests:
See changes to test_get_stim_epoch() in test_epochs.py
### Script to reproduce error and fix:
### Configuration details:

# Checklist
- [x] My code follows
      [Allen Institute Contribution Guidelines](CONTRIBUTING.md)
- [x] My code is unit tested and does not decrease test coverage
- [x] I have performed a self review of my own code
- [ ] My code is well-documented, and the docstrings conform to
      [Numpy Standards](https://numpydoc.readthedocs.io/en/latest/format.html)
- [ ] I have updated the documentation of the repository where
      appropriate
- [x] The header on my commit includes the issue number
- [x] My code passes all tests
- [x] I have updated the CHANGELOG.md with the description of changes understandable by end users

# Notes:
Use this section to add anything you think worth mentioning to the
reader of the issue
