### PR TITLE
Gh-513/check in-bath electrode resistance before extracting baseline electrode current

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 All notable changes to this project will be documented in this file.
 
 ## Unreleased
+This change adds a check of the electrode resistance (eR) for the EXTPINBATH 
+sweep in extract_electrode_0 and only extracts e0 (baseline electrode current)
+if eR is less than max_eR (max allowable electrode resistance). If eR exceeds 
+max_eR then e0 is set to None and new tag that indicates eR exceeds max_eR is 
+appended to tags list.
+
 
 ### Added
 

--- a/ipfx/qc_feature_extractor.py
+++ b/ipfx/qc_feature_extractor.py
@@ -62,7 +62,7 @@ def extract_electrode_0(data_set, tags):
         if eR < max_eR:
             e0 = qcf.measure_electrode_0(bath_data.i, bath_data.sampling_rate)
         else:
-            tags.append("Pipette Resistance {} exceeds max pipette resistance {}".format(eR, max_eR))
+            tags.append("Pipette Resistance {} MOhms exceeds max pipette resistance {} MOhms".format(eR, max_eR))
             e0 = None
 
     except IndexError as e:

--- a/ipfx/qc_feature_extractor.py
+++ b/ipfx/qc_feature_extractor.py
@@ -52,12 +52,18 @@ def extract_electrode_0(data_set, tags):
     """
 
     ontology = data_set.ontology
+    max_eR = 7.5    # max electrode resistance in MOhms 
 
     try:
         bath_sweep_number = data_set.get_sweep_numbers(ontology.bath_names)[-1]
         bath_data = data_set.sweep(bath_sweep_number)
 
-        e0 = qcf.measure_electrode_0(bath_data.i, bath_data.sampling_rate)
+        eR = qcf.measure_input_resistance(bath_data.v, bath_data.i, bath_data.t)
+        if eR < max_eR:
+            e0 = qcf.measure_electrode_0(bath_data.i, bath_data.sampling_rate)
+        else:
+            tags.append("Pipette Resistance {} exceeds max pipette resistance {}".format(eR, max_eR))
+            e0 = None
 
     except IndexError as e:
         tags.append("Electrode 0 is not available")


### PR DESCRIPTION
# Overview:
Verify electrode resistance of EXTPINBATH sweep before extracting e0

This commit checks the value of the electrode resistance (eR) before extracting
the value of the electrode baseline current (e0) with extract_electrode_0 in
qc_feature_extractor.py. After the sweep containing the in-bath data (EXTPINBATH)
is identified, eR is extracted with measure_input_resistance and then e0 is only
extracted if eR is less than the max allowable electrode resistance (max_eR).
If eR is found to exceed max_eR the e0 is set to None and a new tag is applied,
indicating that eR exceeded max_eR.


# Addresses:
Addresses issue https://github.com/AllenInstitute/ipfx/issues/513#issue-866275415

# Type of Fix:
<!--Chose One-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing
      functionality to not work as expected)
- [ ] Documentation Change

# Solution:
This solution first gets the value of the electrode resistance for the EXTPINBATH sweep with 
measure_input_resistance in qc_features and then checks that value to ensure that it is below
the maximum allowable electrode resistance as outlined in the Electrophysiology white paper.
The baseline current of the electrode (e0) is extracted only if the electrode resistance is below the 
max electrode resistance, and if it exceeds the max electrode resistance then e0 is set to None
and the new tag which indicates that the pipette resistance is out of range is appended to the 
tags list. 

# Changes:
- extract_electrode_0 function now calls measure_input_resistance after EXTPINBATH sweep is found
to measure the electrode resistance (eR)
- eR is compared to max_eR (max allowable electrode resistance) and e0 is extracted with
measure_electrode_0 only if eR is less than max_eR.
- If eR exceeds max_eR then e0 is set to None and new tag is appended to tags list to indicate
that eR exceeded max_eR.


# Validation:
This is a pretty simple and straight forward change that does not break anything. This change
is inside of the extract_electrode_0 function which does not have any tests so I have not 
included any tests, but if needed I can refactor my changes into their own function for testing,
but these changes really only introduce a call to measure_input_resistance, which is already 
tested, and the comparison operator '<' for comparing eR to max_eR. 

### Screenshots:
### Unit Tests:
### Script to reproduce error and fix:
### Configuration details:

# Checklist
- [ ] My code follows
      [Allen Institute Contribution Guidelines](CONTRIBUTING.md)
- [ ] My code is unit tested and does not decrease test coverage
- [x] I have performed a self review of my own code
- [ ] My code is well-documented, and the docstrings conform to
      [Numpy Standards](https://numpydoc.readthedocs.io/en/latest/format.html)
- [x] I have updated the documentation of the repository where
      appropriate
- [x] The header on my commit includes the issue number
- [x] My code passes all tests
- [x] I have updated the CHANGELOG.md with the description of changes understandable by end users

# Notes:
Please let me know unit tests are still needed for such a small change and I can refactor 
and add those in.
