### PR TITLE
Address nan issue by selecting recording epoch as default

### DIFF
--- a/ipfx/bin/plot_ephys_nwb.py
+++ b/ipfx/bin/plot_ephys_nwb.py
@@ -1,34 +1,68 @@
 import sys
+import warnings
 import matplotlib.pyplot as plt
 import numpy as np
 from ipfx.dataset.create import create_ephys_data_set
+from ipfx.qc_feature_extractor import sweep_qc_features
+from ipfx.utilities import drop_failed_sweeps
 from ipfx.stimulus import StimulusOntology
 import allensdk.core.json_utilities as ju
+from typing import (
+    Optional, List, Dict, Tuple, Collection, Sequence, Union
+)
 
 
-def plot_data_set(data_set, sweep_table, nwb_file_name):
+def plot_data_set(data_set,
+            clamp_mode: Optional[str] = None,
+            stimuli: Optional[Collection[str]] = None,
+            stimuli_exclude: Optional[Collection[str]] = None,
+            show_amps: Optional[bool] = True,
+            qc_sweeps: Optional[bool] = True,
+            figsize=(15, 7),
+    ):
+    nwb_file_name = str(data_set._data.nwb_file)
+    if qc_sweeps:
+        drop_failed_sweeps(data_set)
+    elif show_amps:
+        data_set.sweep_info = sweep_qc_features(data_set)
 
+    sweep_table = data_set.filtered_sweep_table(clamp_mode=clamp_mode, stimuli=stimuli, stimuli_exclude=stimuli_exclude)
+    
+    if len(sweep_table)==0:
+        warnings.warn("No sweeps to plot")
+        return
+    
     height_ratios, width_ratios = axes_ratios(sweep_table)
 
     fig, ax = plt.subplots(len(height_ratios), 3,
-                           figsize=(15, 7),
+                           figsize=figsize,
                            gridspec_kw={'height_ratios': height_ratios, 'width_ratios': width_ratios}
                            )
+    if len(height_ratios)==1:
+        # ensure 2d array
+        ax = ax[None, :]
 
     for fig_row, (stimulus_code, sweep_set_table) in enumerate(sweep_table.groupby("stimulus_code")):
-        sweep_numbers = sweep_set_table["sweep_number"].sort_values().values
+        sweep_set_table = sweep_set_table.copy().sort_values("sweep_number", ascending=False)
+        sweep_numbers = sweep_set_table["sweep_number"]
         ss = data_set.sweep_set(sweep_numbers)
+        if qc_sweeps:
+            ss.select_epoch('experiment')
+        annot = sweep_numbers.astype(str)
+        if show_amps:
+            annot += sweep_set_table['stimulus_amplitude'].apply(": {:.3g} pA".format)
+            
 
         ax_a = ax[fig_row,0]
         ax_i = ax[fig_row,1]
         ax_v = ax[fig_row,2]
 
-        plot_waveforms(ax_i, ss.i, ss.sampling_rate, ss.sweep_number)
-        plot_waveforms(ax_v, ss.v, ss.sampling_rate, ss.sweep_number)
+        plot_waveforms(ax_i, ss.i, ss.sampling_rate, annot)
+        plot_waveforms(ax_v, ss.v, ss.sampling_rate)
         ax_v.get_shared_x_axes().join(ax_i, ax_v)
 
         clamp_mode = sweep_set_table["clamp_mode"].values[0]
-        ax_a.text(0, 0.0, "%s, %s " % (stimulus_code, clamp_mode))
+        ax_a.text(0, 0.0, "%s \n%s " % (stimulus_code, clamp_mode))
         ax_a.axis('off')
 
     ax[0,0].set_title("Description")
@@ -40,14 +74,15 @@ def plot_data_set(data_set, sweep_table, nwb_file_name):
     fig.suptitle("file: " + nwb_file_name, fontsize=12)
 
     mng = plt.get_current_fig_manager()
-    mng.resize(*mng.window.maxsize())
+    if hasattr(mng, 'window'):
+        mng.resize(*mng.window.maxsize())
     plt.subplots_adjust(left=0.01, right=0.98, bottom=0.02,top=0.92)
 
 
 def axes_ratios(sweep_table):
 
     height_ratios = []
-    width_ratios = [1,3,3]
+    width_ratios = [1,4,4]
 
     for _, sweep_set_table in sweep_table.groupby("stimulus_code"):
         height_ratios.append(len(sweep_set_table.index))
@@ -55,26 +90,32 @@ def axes_ratios(sweep_table):
     return height_ratios, width_ratios
 
 
-def plot_waveforms(ax, ys, rs, sn):
+def plot_waveforms(ax, ys, rs, annotations=None):
 
     offset = 0
-
-    for y, r, sn in zip(ys, rs, sn):
-
-        offset += get_vertical_offset(y)
+    dy = 0
+    for i, (y, r) in enumerate(zip(ys, rs)):
+        if len(y)==0:
+            continue
+        y -= y[0]
+        dy = max(dy, get_vertical_offset(y))
+        offset += dy
         y += offset
         x = np.arange(0, len(y)) / r
 
         ax.plot(x, y)
-        ax.text(x[0] - 0.05 * (x[-1] - x[0]), y[0], str(sn), fontsize=8)
-        ax.set_xlim(x[0], x[-1])
+        if annotations is not None:
+            ax.text(x[0] - 0.01 * (x[-1] - x[0]), y[0], annotations.iloc[i], fontsize=8, ha='right')
+    # need to set limits to show all sweeps
+    # mode would be best but mean will do fine
+    ax.set_xlim(0, np.max([len(y) for y in ys])/r)
 
     customize_axis(ax)
 
 
 def customize_axis(ax):
 
-    ax.tick_params(axis="x", direction="in", pad=-10,labelsize=8)
+    ax.tick_params(axis="x", direction="in", pad=3, labelsize=8)
     ax.get_yaxis().set_visible(False)
     ax.spines['top'].set_visible(False)
     ax.spines['right'].set_visible(False)
@@ -102,12 +143,8 @@ def main():
     ont = StimulusOntology(ju.read(stimulus_ontology_file))
 
     data_set = create_ephys_data_set(nwb_file=nwb_file)
-    vclamp_sweep_table = data_set.filtered_sweep_table(clamp_mode=data_set.VOLTAGE_CLAMP)
-    plot_data_set(data_set, vclamp_sweep_table, nwb_file)
-
-    data_set = create_ephys_data_set(nwb_file=nwb_file)
-    iclamp_sweep_table = data_set.filtered_sweep_table(clamp_mode=data_set.CURRENT_CLAMP)
-    plot_data_set(data_set, iclamp_sweep_table, nwb_file)
+    plot_data_set(data_set, clamp_mode=data_set.VOLTAGE_CLAMP)
+    plot_data_set(data_set, clamp_mode=data_set.CURRENT_CLAMP)
 
     plt.show()
 

--- a/ipfx/data_set_features.py
+++ b/ipfx/data_set_features.py
@@ -160,7 +160,6 @@ def extract_sweep_features(data_set, sweep_table):
         sweep_numbers = sorted(sweep_numbers)
 
         sweep_set = data_set.sweep_set(sweep_numbers)
-        sweep_set.select_epoch("recording")
         sweep_set.align_to_start_of_epoch("experiment")
 
         dp = detection_parameters(stimulus_name).copy()
@@ -238,7 +237,6 @@ def extract_cell_long_square_features(data_set, subthresh_min_amp=None):
             logging.info("Assigned subthreshold minimum amplitude of %f.", subthresh_min_amp)
 
     lsq_sweeps = data_set.sweep_set(long_square_sweep_numbers)
-    lsq_sweeps.select_epoch("recording")
     lsq_sweeps.align_to_start_of_epoch("experiment")
 
     lsq_start, lsq_dur, _, _, _ = stf.get_stim_characteristics(
@@ -278,7 +276,6 @@ def extract_cell_short_square_features(data_set):
         raise er.FeatureError("No short square sweeps available for feature extraction")
 
     ssq_sweeps = data_set.sweep_set(short_square_sweep_numbers)
-    ssq_sweeps.select_epoch("recording")
     ssq_sweeps.align_to_start_of_epoch("experiment")
 
     ssq_start, ssq_dur, _, _, _ = stf.get_stim_characteristics(
@@ -312,7 +309,6 @@ def extract_cell_ramp_features(data_set):
         raise er.FeatureError("No ramp sweeps available for feature extraction")
 
     ramp_sweeps = data_set.sweep_set(ramp_sweep_numbers)
-    ramp_sweeps.select_epoch("recording")
     ramp_sweeps.align_to_start_of_epoch("experiment")
 
     ramp_start, ramp_dur, _, _, _ = stf.get_stim_characteristics(ramp_sweeps.sweeps[0].i, ramp_sweeps.sweeps[0].t)

--- a/ipfx/dataset/ephys_data_set.py
+++ b/ipfx/dataset/ephys_data_set.py
@@ -313,17 +313,7 @@ class EphysDataSet(object):
             }
         """
         sweep_data = cp.copy(self._data.get_sweep_data(sweep_number))
-
-        response = sweep_data['response']
-
-        nonzero = np.flatnonzero(response)
-        if len(nonzero) == 0:
-            recording_end_idx = 0
-        else:
-            recording_end_idx = nonzero[-1] + 1
-
-        sweep_data["response"] = response[:recording_end_idx]
-        sweep_data["stimulus"] = sweep_data["stimulus"][:recording_end_idx]
+        sweep_data["response"] = _nan_trailing_zeros(sweep_data["response"])
 
         return sweep_data
 
@@ -433,3 +423,21 @@ class EphysDataSet(object):
             )
 
         return voltage, current
+
+def _nan_trailing_zeros(
+        array: np.ndarray, 
+        inplace: bool = False
+) -> np.ndarray:
+    """If an array ends with one or more zeros, replace those zeros with 
+    np.nan
+    """
+
+    if not inplace:
+        array = array.copy()
+
+    nonzero = np.flatnonzero(array)
+    if len(nonzero) == 0 or nonzero[-1] + 1 >= len(array):
+        return array
+
+    array[nonzero[-1] + 1:] = np.nan
+    return array

--- a/ipfx/script_utils.py
+++ b/ipfx/script_utils.py
@@ -179,7 +179,6 @@ def categorize_iclamp_sweeps(data_set, stimuli_names, sweep_qc_option="none", sp
 
 def validate_sweeps(data_set, sweep_numbers, extra_dur=0.2):
     check_sweeps = data_set.sweep_set(sweep_numbers)
-    check_sweeps.select_epoch("recording")
     valid_sweep_stim = []
     start = None
     dur = None
@@ -216,7 +215,6 @@ def preprocess_long_square_sweeps(data_set, sweep_numbers, extra_dur=0.2, subthr
     lsq_sweeps, lsq_start, lsq_end = validate_sweeps(data_set, sweep_numbers, extra_dur=extra_dur)
     if len(lsq_sweeps.sweeps) == 0:
         raise er.FeatureError("No long square sweeps were long enough or did not end early")
-    lsq_sweeps.select_epoch("recording")
 
     lsq_spx, lsq_spfx = dsf.extractors_for_sweeps(
         lsq_sweeps,
@@ -239,7 +237,6 @@ def preprocess_short_square_sweeps(data_set, sweep_numbers, extra_dur=0.2, spike
     ssq_sweeps, ssq_start, ssq_end  = validate_sweeps(data_set, sweep_numbers, extra_dur=extra_dur)
     if len(ssq_sweeps.sweeps) == 0:
         raise er.FeatureError("No short square sweeps were long enough or did not end early")
-    ssq_sweeps.select_epoch("recording")
 
     ssq_spx, ssq_spfx = dsf.extractors_for_sweeps(ssq_sweeps,
                                                   est_window = [ssq_start, ssq_start + 0.001],
@@ -258,7 +255,6 @@ def preprocess_ramp_sweeps(data_set, sweep_numbers):
         raise er.FeatureError("No ramp sweeps available for feature extraction")
 
     ramp_sweeps = data_set.sweep_set(sweep_numbers)
-    ramp_sweeps.select_epoch("recording")
 
     ramp_start, ramp_dur, _, _, _ = stf.get_stim_characteristics(ramp_sweeps.sweeps[0].i, ramp_sweeps.sweeps[0].t)
     ramp_spx, ramp_spfx = dsf.extractors_for_sweeps(ramp_sweeps,

--- a/ipfx/sweep.py
+++ b/ipfx/sweep.py
@@ -14,7 +14,7 @@ class Sweep(object):
         else:
             self.epochs = {}
 
-        self.selected_epoch_name = "sweep"
+        self.selected_epoch_name = "recording"
 
         if self.clamp_mode == "CurrentClamp":
             self.response = self._v

--- a/ipfx/sweep.py
+++ b/ipfx/sweep.py
@@ -14,16 +14,15 @@ class Sweep(object):
         else:
             self.epochs = {}
 
-        self.selected_epoch_name = "recording"
-
         if self.clamp_mode == "CurrentClamp":
-            self.response = self._v
-            self.stimulus = self._i
+            self._response = self._v
+            self._stimulus = self._i
         else:
-            self.response = self._i
-            self.stimulus = self._v
+            self._response = self._i
+            self._stimulus = self._v
 
         self.detect_epochs()
+        self.selected_epoch_name = "recording"
 
     @property
     def t(self):
@@ -54,22 +53,23 @@ class Sweep(object):
         """
 
         if "test" not in self.epochs:
-            self.epochs["test"] = ep.get_test_epoch(self.stimulus,self.sampling_rate)
+            self.epochs["test"] = ep.get_test_epoch(self._stimulus, self.sampling_rate)
         if self.epochs["test"]:
             test_pulse = True
         else:
             test_pulse = False
 
-        epoch_detectors = {
-            "sweep": ep.get_sweep_epoch(self.response),
-            "recording": ep.get_recording_epoch(self.response),
-            "experiment": ep.get_experiment_epoch(self._i, self.sampling_rate,test_pulse),
-            "stim": ep.get_stim_epoch(self.stimulus, test_pulse),
-        }
-
-        for epoch_name, epoch_detector in epoch_detectors.items():
-            if epoch_name not in self.epochs:
-                self.epochs[epoch_name] = epoch_detector
+        if "sweep" not in self.epochs:
+            self.epochs["sweep"] = ep.get_sweep_epoch(self._i)
+        self.select_epoch("sweep")
+        if "recording" not in self.epochs:
+            self.epochs["recording"] = ep.get_recording_epoch(self._response)
+        self.select_epoch("recording")
+        stim = self.i if self.clamp_mode == "CurrentClamp" else self.v
+        if "stim" not in self.epochs:
+            self.epochs["stim"] = ep.get_stim_epoch(stim, test_pulse)
+        if "experiment" not in self.epochs:
+            self.epochs["experiment"] = ep.get_experiment_epoch(stim, self.sampling_rate, test_pulse)
 
 
 class SweepSet(object):

--- a/ipfx/sweep.py
+++ b/ipfx/sweep.py
@@ -61,9 +61,9 @@ class Sweep(object):
 
         if "sweep" not in self.epochs:
             self.epochs["sweep"] = ep.get_sweep_epoch(self._i)
-        self.select_epoch("sweep")
         if "recording" not in self.epochs:
             self.epochs["recording"] = ep.get_recording_epoch(self._response)
+        # get valid recording by selecting epoch and using i/v prop before detecting stim
         self.select_epoch("recording")
         stim = self.i if self.clamp_mode == "CurrentClamp" else self.v
         if "stim" not in self.epochs:

--- a/tests/test_chirp.py
+++ b/tests/test_chirp.py
@@ -9,9 +9,8 @@ def test_chirp_output():
     sampling_rate = 2000
     t = np.arange(0, 20 * sampling_rate) * (1 / sampling_rate)
     clamp_mode = "CurrentClamp"
-    epochs = {"sweep": (0, len(t) - 1),
+    epochs = {"recording": (0, len(t) - 1),
         "test": None,
-        "recording": None,
         "experiment": None,
         "stim": None}
 
@@ -52,9 +51,8 @@ def test_chirp_downsample():
     sampling_rate = 2000
     t = np.arange(0, 20 * sampling_rate) * (1 / sampling_rate)
     clamp_mode = "CurrentClamp"
-    epochs = {"sweep": (0, len(t) - 1),
+    epochs = {"recording": (0, len(t) - 1),
         "test": None,
-        "recording": None,
         "experiment": None,
         "stim": None}
 
@@ -80,9 +78,8 @@ def test_divide_chirps_by_stimulus():
     sampling_rate = 2000
     t = np.arange(0, 20 * sampling_rate) * (1 / sampling_rate)
     clamp_mode = "CurrentClamp"
-    epochs = {"sweep": (0, len(t) - 1),
+    epochs = {"recording": (0, len(t) - 1),
         "test": None,
-        "recording": None,
         "experiment": None,
         "stim": None}
 

--- a/tests/test_feature_vector.py
+++ b/tests/test_feature_vector.py
@@ -333,9 +333,8 @@ def test_step_subthreshold_interpolation():
     t = np.arange(6)
     i = np.zeros_like(t)
     epochs = {
-        "sweep": (0, 5),
+        "recording": (0, 5),
         "test": None,
-        "recording": None,
         "experiment": None,
         "stim": None,
     }
@@ -367,9 +366,8 @@ def test_subthresh_norm_normalization():
     t = np.arange(len(v))
     i = np.zeros_like(t)
     epochs = {
-        "sweep": (0, len(v) - 1),
+        "recording": (0, len(v) - 1),
         "test": None,
-        "recording": None,
         "experiment": None,
         "stim": None,
     }
@@ -414,9 +412,8 @@ def test_subthresh_depol_norm_normalization():
     t = np.arange(len(v))
     i = np.zeros_like(t)
     epochs = {
-        "sweep": (0, len(v) - 1),
+        "recording": (0, len(v) - 1),
         "test": None,
-        "recording": None,
         "experiment": None,
         "stim": None,
     }
@@ -505,9 +502,8 @@ def test_first_ap_correct_section():
     t = np.arange(len(v))
     i = np.zeros_like(t)
     epochs = {
-        "sweep": (0, len(v) - 1),
+        "recording": (0, len(v) - 1),
         "test": None,
-        "recording": None,
         "experiment": None,
         "stim": None,
     }
@@ -537,9 +533,8 @@ def test_first_ap_resampling():
     t = np.arange(len(v))
     i = np.zeros_like(t)
     epochs = {
-        "sweep": (0, len(v) - 1),
+        "recording": (0, len(v) - 1),
         "test": None,
-        "recording": None,
         "experiment": None,
         "stim": None,
     }
@@ -752,9 +747,8 @@ def test_identify_sub_hyperpol_levels():
     t = np.arange(len(v))
     i = np.zeros_like(t)
     epochs = {
-        "sweep": (0, len(v) - 1),
+        "recording": (0, len(v) - 1),
         "test": None,
-        "recording": None,
         "experiment": None,
         "stim": None,
     }
@@ -810,9 +804,8 @@ def test_identify_sub_depol_levels_with_subthreshold_sweeps():
     t = np.arange(len(v))
     i = np.zeros_like(t)
     epochs = {
-        "sweep": (0, len(v) - 1),
+        "recording": (0, len(v) - 1),
         "test": None,
-        "recording": None,
         "experiment": None,
         "stim": None,
     }
@@ -866,9 +859,8 @@ def test_identify_sub_depol_levels_without_subthreshold_sweeps():
     t = np.arange(len(v))
     i = np.zeros_like(t)
     epochs = {
-        "sweep": (0, len(v) - 1),
+        "recording": (0, len(v) - 1),
         "test": None,
-        "recording": None,
         "experiment": None,
         "stim": None,
     }
@@ -923,9 +915,8 @@ def test_identify_isi_shape_min_spike():
     t = np.arange(n_points)
     i = np.zeros_like(t)
     epochs = {
-        "sweep": (0, n_points - 1),
+        "recording": (0, n_points - 1),
         "test": None,
-        "recording": None,
         "experiment": None,
         "stim": None,
     }
@@ -963,9 +954,8 @@ def test_identify_isi_shape_largest_below_min_spike():
     t = np.arange(n_points)
     i = np.zeros_like(t)
     epochs = {
-        "sweep": (0, n_points - 1),
+        "recording": (0, n_points - 1),
         "test": None,
-        "recording": None,
         "experiment": None,
         "stim": None,
     }
@@ -1003,9 +993,8 @@ def test_identify_isi_shape_one_spike():
     t = np.arange(n_points)
     i = np.zeros_like(t)
     epochs = {
-        "sweep": (0, n_points - 1),
+        "recording": (0, n_points - 1),
         "test": None,
-        "recording": None,
         "experiment": None,
         "stim": None,
     }
@@ -1086,9 +1075,8 @@ def test_isi_shape_aligned():
     t = np.arange(len(v))
     i = np.zeros_like(t)
     epochs = {
-        "sweep": (0, len(v) - 1),
+        "recording": (0, len(v) - 1),
         "test": None,
-        "recording": None,
         "experiment": None,
         "stim": None,
     }
@@ -1129,9 +1117,8 @@ def test_isi_shape_skip_short():
     t = np.arange(len(v))
     i = np.zeros_like(t)
     epochs = {
-        "sweep": (0, len(v) - 1),
+        "recording": (0, len(v) - 1),
         "test": None,
-        "recording": None,
         "experiment": None,
         "stim": None,
     }
@@ -1180,9 +1167,8 @@ def test_isi_shape_one_spike():
     t = np.arange(len(v))
     i = np.zeros_like(t)
     epochs = {
-        "sweep": (0, len(v) - 1),
+        "recording": (0, len(v) - 1),
         "test": None,
-        "recording": None,
         "experiment": None,
         "stim": None,
     }

--- a/tests/test_sweep.py
+++ b/tests/test_sweep.py
@@ -16,6 +16,7 @@ def sweep():
 
 def test_select_epoch(sweep):
 
+    sweep.select_epoch("sweep")
     i_sweep = sweep.i
     v_sweep = sweep.v
 


### PR DESCRIPTION
# Overview:
One of two options to address issue #508 by selecting the recording epoch by default as sweeps are created.

# Type of Fix:
<!--Chose One-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing
      functionality to not work as expected)
- [ ] Documentation Change

# Solution:
The recording epoch already properly detects the valid portion of sweeps, but isn't always used in the early stages of QC or when detecting the stim epoch. By making sure it's always used, the full sweep info from the NWB is retained, but all code runs properly by dealing with the valid portion only.

# Changes:
- selects recording rather than sweep epoch by default, and removes redundant calls to select recording epoch
- restructures epoch detection to use recording epoch for stim epoch detection also
- restores previous behavior for missing data represented as zeros, replacing with nan rather than truncating
- fixes tests for compatibility with changes
- improved plot_data_set for quick visualization of new NWB2 to assess epochs


# Validation:
Checked that tests pass and that epochs are found correctly without error in a new MIES NWB2 file using the updated plot_data_set
```
from ipfx.bin.plot_ephys_nwb import plot_data_set
from ipfx.dataset.create import create_ephys_data_set
path = '/allen/programs/celltypes/production/humancelltypes/prod148/Ephys_Roi_Result_1077533543/H21.26.402.12.58.01.05.nwb'
data_set = create_ephys_data_set(path)
plot_data_set(data_set, clamp_mode='CurrentClamp', show_amps=True, qc_sweeps=True)
```


# Checklist
- [x] My code follows
      [Allen Institute Contribution Guidelines](CONTRIBUTING.md)
- [x] My code is unit tested and does not decrease test coverage
- [x] I have performed a self review of my own code
- [x] My code is well-documented, and the docstrings conform to
      [Numpy Standards](https://numpydoc.readthedocs.io/en/latest/format.html)
- [ ] I have updated the documentation of the repository where
      appropriate
- [ ] The header on my commit includes the issue number
- [x] My code passes all tests
- [ ] I have updated the CHANGELOG.md with the description of changes understandable by end users

