### PR TITLE
Fix duration rounding to address #521

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@ All notable changes to this project will be documented in this file.
 ### Added
 
 ### Changed
-
+- Round the duration calculation in `run_feature_vector_extraction` so that
+vectors of the same length are produced even when floating point approximations
+of times are different.
 
 ## [1.0.3] = 2021-02-02
 Changed:

--- a/ipfx/bin/run_feature_vector_extraction.py
+++ b/ipfx/bin/run_feature_vector_extraction.py
@@ -168,8 +168,11 @@ def data_for_specimen_id(
         (subthresh_depol_dict,
         depol_deflect_dict) = fv.identify_subthreshold_depol_with_amplitudes(lsq_features,
             lsq_sweeps)
-        result["subthresh_depol_norm"] = fv.subthresh_depol_norm(subthresh_depol_dict,
-            depol_deflect_dict, lsq_start, lsq_end)
+        result["subthresh_depol_norm"] = fv.subthresh_depol_norm(
+            subthresh_depol_dict,
+            depol_deflect_dict,
+            np.round(lsq_start, decimals=3),
+            np.round(lsq_end, decimals=3))
         isi_sweep, isi_sweep_spike_info = fv.identify_sweep_for_isi_shape(
             lsq_sweeps, lsq_features, lsq_end - lsq_start)
         result["isi_shape"] = fv.isi_shape(isi_sweep, isi_sweep_spike_info, lsq_end)

--- a/ipfx/feature_vectors.py
+++ b/ipfx/feature_vectors.py
@@ -723,7 +723,10 @@ def psth_vector(spike_info_list, start, end, width=50):
         thresh_t = si["threshold_t"]
         spike_count = np.ones_like(thresh_t)
         one_ms = 0.001
-        duration = end - start
+
+        # round to nearest ms to deal with float approximations
+        duration = np.round(end, decimals=3) - np.round(start, decimals=3)
+
         n_bins = int(duration / one_ms) // width
         bin_edges = np.linspace(start, end, n_bins + 1) # includes right edge, so adding one to desired bin number
         bin_width = bin_edges[1] - bin_edges[0]
@@ -769,7 +772,10 @@ def inst_freq_vector(spike_info_list, start, end, width=20):
         inst_freq, inst_freq_times = _inst_freq_feature(thresh_t, start, end)
 
         one_ms = 0.001
-        duration = end - start
+
+        # round to nearest ms to deal with float approximations
+        duration = np.round(end, decimals=3) - np.round(start, decimals=3)
+
         n_bins = int(duration / one_ms) // width
         bin_edges = np.linspace(start, end, n_bins + 1) # includes right edge, so adding one to desired bin number
         bin_width = bin_edges[1] - bin_edges[0]
@@ -826,7 +832,10 @@ def spike_feature_vector(feature, spike_info_list, start, end, width=20):
             feature_values = feature_values[mask]
 
         one_ms = 0.001
-        duration = end - start
+
+        # round to nearest ms to deal with float approximations
+        duration = np.round(end, decimals=3) - np.round(start, decimals=3)
+
         n_bins = int(duration / one_ms) // width
         bin_edges = np.linspace(start, end, n_bins + 1) # includes right edge, so adding one to desired bin number
         bin_width = bin_edges[1] - bin_edges[0]

--- a/tests/data/feature_vector/fv_inst_freq_TEMP.npy
+++ b/tests/data/feature_vector/fv_inst_freq_TEMP.npy
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6d67149d866cf209c80e6b9bd08bdf7ee7cf0d5556d3359aef4cbd1e2d55ba04
-size 4832
+oid sha256:070c61ec83138f6369bade59da292c0ec2da2e313a0f118290f4308cb5d48c13
+size 4928

--- a/tests/data/feature_vector/fv_psth_TEMP.npy
+++ b/tests/data/feature_vector/fv_psth_TEMP.npy
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:10af0f01a42ad4711ddda5f2e1b10d9b451168d518849055ee5eb24fb29eac57
-size 1952
+oid sha256:086402a460cde17173d0b751cae77528f4e9c7051604125e245bafc1da963c15
+size 2048

--- a/tests/data/feature_vector/fv_spiking_fast_trough_v_TEMP.npy
+++ b/tests/data/feature_vector/fv_spiking_fast_trough_v_TEMP.npy
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:99a235ea93f8828ed5fc395dbfbabcba255f96924c744b76a83534d43f916514
-size 4832
+oid sha256:2b38d6066dd6068638b1a1661bcf770ca6a5d2eb92cbb893b129b449f1609a4f
+size 4928

--- a/tests/data/feature_vector/fv_spiking_peak_v_TEMP.npy
+++ b/tests/data/feature_vector/fv_spiking_peak_v_TEMP.npy
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:89303910ada6806ab90dec501b2d54639b17a06d30d0a4081f78cfc5159ac112
-size 4832
+oid sha256:a35aabce34971b767f57009cfe472758106574b5cc67056a0921083b9bcad35f
+size 4928

--- a/tests/data/feature_vector/fv_spiking_threshold_v_TEMP.npy
+++ b/tests/data/feature_vector/fv_spiking_threshold_v_TEMP.npy
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:230e721666249d239a56761660a0ae5254be00a5a9ea0940c58f1e66c0fa9a8f
-size 4832
+oid sha256:711efa63b0f1fc063df297a78594b5a36b0e85dbd1d2b95cd0afafc519f1ac9d
+size 4928

--- a/tests/data/feature_vector/fv_spiking_upstroke_downstroke_ratio_TEMP.npy
+++ b/tests/data/feature_vector/fv_spiking_upstroke_downstroke_ratio_TEMP.npy
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f1945202e2ceb0555abbe0b8437fe92c71658ce345ca7e2e954c25dbddb6a318
-size 4832
+oid sha256:7716d3f24c2ebcf5c2027f353853abc4d1ef3c6cd8cf62806bce4a5461b21549
+size 4928

--- a/tests/data/feature_vector/fv_spiking_width_TEMP.npy
+++ b/tests/data/feature_vector/fv_spiking_width_TEMP.npy
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6288bfd7b0c389a3f9be14714b7842984f0be4860bdebbb18e87c4bf22374b50
-size 4832
+oid sha256:0b4d819636ab80f04b3bf4ac8fcfa095c0378c1cdb91e9e1cf0928460079dbbb
+size 4928

--- a/tests/test_feature_vector.py
+++ b/tests/test_feature_vector.py
@@ -274,16 +274,16 @@ def test_isi_shape():
             return np.arange(20)
 
     obtained = fv.isi_shape(
-        Sweep(), 
-        pd.DataFrame(sweep_spike_info), 
-        50, 
+        Sweep(),
+        pd.DataFrame(sweep_spike_info),
+        50,
         n_points=10
     )
     assert np.allclose(np.arange(3.5, 13.5, 1.0), obtained)
 
 
 def test_identify_subthreshold_hyperpol_with_amplitudes(subthreshold_sweeps):
-  
+
     class SomeSweeps:
         @property
         def sweeps(self):
@@ -298,8 +298,8 @@ def test_identify_subthreshold_hyperpol_with_amplitudes(subthreshold_sweeps):
         )
 
     expected = {
-        -30.0: np.array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]), 
-        -50.0: np.array([11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21]), 
+        -30.0: np.array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]),
+        -50.0: np.array([11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21]),
         -70.0: np.array([22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32])
     }
 
@@ -460,11 +460,11 @@ def test_identify_subthreshold_depol_with_amplitudes(subthreshold_sweeps):
 
     expected = {
         "amp": {
-            470.0: np.array([33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43]), 
+            470.0: np.array([33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43]),
             480.0: np.array([44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54])
         },
         "deflect": {
-            470.0: (-68.29730987548828, -30.550001), 
+            470.0: (-68.29730987548828, -30.550001),
             480.0: (-68.26968383789062, -28.54375)
         }
     }
@@ -627,6 +627,24 @@ def test_psth_between_sweep_interpolation():
     )
 
 
+def test_psth_duration_rounding():
+    start_a, end_a = 1.02, 2.02
+    start_b, end_b = 1.02, 2.0199999999999996
+
+    np.random.seed(42)
+    n_spikes = np.random.randint(0, 100)
+
+    test_spike_times = np.random.random(n_spikes) * (end_a - start_a) + start_a
+    spike_info = pd.DataFrame({"threshold_t": test_spike_times})
+
+    width = 50
+
+    output_a = fv.psth_vector([spike_info], start=start_a, end=end_a, width=width)
+    output_b = fv.psth_vector([spike_info], start=start_b, end=end_b, width=width)
+
+    assert output_a.shape == output_b.shape
+
+
 def test_inst_freq_one_spike():
     test_spike_times = [0.2]
     spike_info = pd.DataFrame({"threshold_t": test_spike_times})
@@ -674,6 +692,21 @@ def test_inst_freq_between_sweep_interpolation():
             axis=0
         ),
     )
+
+
+def test_inst_freq_duration_rounding():
+    start_a, end_a = 1.02, 2.02
+    start_b, end_b = 1.02, 2.0199999999999996
+
+    test_spike_times = [1.2, 1.5, 1.6, 1.7]
+    spike_info = pd.DataFrame({"threshold_t": test_spike_times})
+
+    width = 20
+
+    output_a = fv.inst_freq_vector([spike_info], start=start_a, end=end_a, width=width)
+    output_b = fv.inst_freq_vector([spike_info], start=start_b, end=end_b, width=width)
+
+    assert output_a.shape == output_b.shape
 
 
 def test_spike_feature_within_sweep_interpolation():
@@ -727,6 +760,31 @@ def test_spike_feature_between_sweep_interpolation():
     assert np.all(output[2 * n_bins : 3 * n_bins] == np.mean(test_feature_values))
     assert np.all(output[3 * n_bins : 4 * n_bins] == test_feature_values[1])
     assert np.all(output[4 * n_bins : 5 * n_bins] == test_feature_values[1])
+
+
+def test_spike_feature_duration_rounding():
+    start_a, end_a = 1.02, 2.02
+    start_b, end_b = 1.02, 2.0199999999999996
+
+    test_spike_times = [1.2, 1.5, 1.6, 1.7]
+
+    feature = "test_feature_name"
+    test_feature_values = [1, 2, 3, 4]
+
+    spike_info = pd.DataFrame({
+        "threshold_t": test_spike_times,
+        "clipped": np.zeros_like(test_spike_times).astype(bool),
+        feature: test_feature_values,
+    })
+
+    width = 20
+
+    output_a = fv.spike_feature_vector(
+        feature, [spike_info], start=start_a, end=end_a, width=width)
+    output_b = fv.spike_feature_vector(
+        feature, [spike_info], start=start_b, end=end_b, width=width)
+
+    assert output_a.shape == output_b.shape
 
 
 def test_identify_sub_hyperpol_levels():


### PR DESCRIPTION
Thank you for contributing to the IPFX, your work and time will help to
advance open science! 

# Overview:
Give a brief overview of the issue you are solving. Succinctly
explain the GitHub issue you are addressing and the underlying problem
of the ticket. The commit header and body should also include this
message, for good commit messages see the [contribution guidelines](CONTRIBUTING.md).

The feature vector extraction code sometimes produces vectors of different lengths that cannot be saved as an array in an H5 file. This happens because of differences in the floating point approximations of start and end times in different cells.


# Addresses:
Add a link to the issue on Github board

Addresses issue #521 

# Type of Fix:
<!--Chose One-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing
      functionality to not work as expected)
- [ ] Documentation Change

# Solution:
Outline your solution to the previously described issue and
underlying cause. This section should include a brief description of
your proposed solution and how it addresses the cause of the ticket

Round the start and end values to the nearest millisecond before calculating the duration in spike-related feature vector calculations.

# Changes:
Include a bulleted list or check box list of the implemented changes
in brief, as well as the addition of supplementary materials (unit tests,
integration tests, etc

- Implemented fix in `psth_vector`, `inst_freq_vector`, and `spike_feature_vector`
- Added unit tests for each of those functions

# Validation:
Describe how you have validated that your solution addresses the
root cause of the ticket. What have you done to ensure that your
addition is bug free and works as expected? Please provide specific
instructions so we can reproduce and list any relevant details about
your configuration

Example script reproducing issue now runs to completion, and new unit tests pass.

### Screenshots:
### Unit Tests:

- added three tests to `test_feature_vector.py`

### Script to reproduce error and fix:

script that demonstrates error:
```python
from ipfx.bin.run_feature_vector_extraction import run_feature_vector_extraction

specimen_id_list = [898949412, 950300190, 645380099]
file_list = {
    898949412: "/path/to/file/nwb2_Rbp4-Cre_KL100;Ai14-471971.03.02.01.nwb",
    950300190: "/path/to/file/nwb2_Rbp4-Cre_KL100;Ai14-487123.05.02.03.nwb",
    645380099: "/path/to/file/nwb2_Sim1-Cre_KJ18;Ai14-354911.06.01.01.nwb",
}
ontology = StimulusOntology(ju.read(StimulusOntology.DEFAULT_STIMULUS_ONTOLOGY_FILE))
data_source = "filesystem"

run_feature_vector_extraction(
    output_dir=".",
    data_source="filesystem",
    output_code="test",
    project="test",
    output_file_type="h5",
    sweep_qc_option="none",
    run_parallel=False,
    ap_window_length=0.003,
    include_failed_cells=False,
    ids=specimen_id_list,
    file_list=file_list
)
```

Currently produces:
```
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-6-e7008fd82f41> in <module>
     10     include_failed_cells=False,
     11     ids=specimen_id_list,
---> 12     file_list=file_list
     13 )

/local1/repos/ipfx/ipfx/bin/run_feature_vector_extraction.py in run_feature_vector_extraction(output_dir, data_source, output_code, project, output_file_type, sweep_qc_option, include_failed_cells, run_parallel, ap_window_length, ids, file_list, **kwargs)
    316 
    317     if output_file_type == "h5":
--> 318         su.save_results_to_h5(used_ids, results_dict, output_dir, output_code)
    319     elif output_file_type == "npy":
    320         su.save_results_to_npy(used_ids, results_dict, output_dir, output_code)

/local1/repos/ipfx/ipfx/script_utils.py in save_results_to_h5(specimen_ids, results_dict, output_dir, output_code)
    314         data = results_dict[k]
    315         dset = h5_file.create_dataset(k, data.shape, dtype=data.dtype,
--> 316             compression="gzip")
    317         dset[...] = data
    318     dset = h5_file.create_dataset("ids", ids_arr.shape,

/local1/anaconda3/envs/py3/lib/python3.7/site-packages/h5py/_hl/group.py in create_dataset(self, name, shape, dtype, data, **kwds)
    134 
    135         with phil:
--> 136             dsid = dataset.make_new_dset(self, shape, dtype, data, **kwds)
    137             dset = dataset.Dataset(dsid)
    138             if name is not None:

/local1/anaconda3/envs/py3/lib/python3.7/site-packages/h5py/_hl/dataset.py in make_new_dset(parent, shape, dtype, data, chunks, compression, shuffle, fletcher32, maxshape, compression_opts, fillvalue, scaleoffset, track_times, external, track_order, dcpl)
    116         else:
    117             dtype = numpy.dtype(dtype)
--> 118         tid = h5t.py_create(dtype, logical=1)
    119 
    120     # Legacy

h5py/h5t.pyx in h5py.h5t.py_create()

h5py/h5t.pyx in h5py.h5t.py_create()

h5py/h5t.pyx in h5py.h5t.py_create()

TypeError: Object dtype dtype('O') has no native HDF5 equivalent
```

After fix produces:
No message (runs to completion)


### Configuration details:

# Checklist
- [x] My code follows
      [Allen Institute Contribution Guidelines](CONTRIBUTING.md)
- [x] My code is unit tested and does not decrease test coverage
- [x] I have performed a self review of my own code
- [x] My code is well-documented, and the docstrings conform to
      [Numpy Standards](https://numpydoc.readthedocs.io/en/latest/format.html)
- [x] I have updated the documentation of the repository where
      appropriate
- [x] The header on my commit includes the issue number
- [x] My code passes all tests
- [x] I have updated the CHANGELOG.md with the description of changes understandable by end users

# Notes:
Use this section to add anything you think worth mentioning to the
reader of the issue
