### PR TITLE
require stim offset to define epoch

### DIFF
--- a/ipfx/epochs.py
+++ b/ipfx/epochs.py
@@ -113,7 +113,7 @@ def get_stim_epoch(i, test_pulse=True):
     if test_pulse:
         di_idx = di_idx[2:]     # drop the first up/down (test pulse) if present
 
-    if len(di_idx) == 0:    # if no stimulus is found
+    if len(di_idx) < 2:    # if no stimulus is found
         return None
 
     start_idx = di_idx[0] + 1   # shift by one to compensate for diff()


### PR DESCRIPTION
Addresses #525 by adjusting get_stimulus_epoch to require a complete stimulus (both onset and offset) to define the stimulus epoch. 
Along with the already merged fixes, this should supersede #511 I believe.