### PR TITLE
Bugfix/525 null duration

### DIFF
--- a/RELEASE_INSTRUCTIONS.md
+++ b/RELEASE_INSTRUCTIONS.md
@@ -25,7 +25,7 @@ or a predetermined release date is approaching
 
 - [ ] Bump the version in version.txt, if not bumped CI deployment to PyPi will fail
 - [ ] Set release version with "git tag v#.#.#" (e.g. "git tag v1.0.0", equivalent to the version you bumped to), this triggers circleci to publish ipfx to pypi
-  - [ ] [Deployment Plan](http://bamboo.corp.alleninstitute.org/deploy/viewDeploymentProjectEnvironments.action?id=164855841)
+  - [ ] [Build](http://bamboo.corp.alleninstitute.org/deploy/viewDeploymentProjectEnvironments.action?id=164855841) and [Deploy](http://bamboo.corp.alleninstitute.org/deploy/viewDeploymentProjectEnvironments.action?id=164855841) IPFX Nightly
 - [ ] After release/deployment, merge master branch (bug fixes,  document generation, etc.) back into dev and delete the release branch
 - [ ] Announce release on https://community.brain-map.org
 

--- a/ipfx/epochs.py
+++ b/ipfx/epochs.py
@@ -113,7 +113,7 @@ def get_stim_epoch(i, test_pulse=True):
     if test_pulse:
         di_idx = di_idx[2:]     # drop the first up/down (test pulse) if present
 
-    if len(di_idx) == 0:    # if no stimulus is found
+    if len(di_idx) < 2:    # if no stimulus is found
         return None
 
     start_idx = di_idx[0] + 1   # shift by one to compensate for diff()


### PR DESCRIPTION
Addresses #525 by adjusting get_stimulus_epoch to require a complete stimulus (both onset and offset) to define the stimulus epoch.
Along with the already merged fixes, this should supersede #511 I believe.