### PR TITLE
bugfix / pause + burst detection 

### DIFF
--- a/ipfx/feature_extractor.py
+++ b/ipfx/feature_extractor.py
@@ -284,7 +284,7 @@ class SpikeTrainFeatureExtractor(object):
 
         if features["avg_rate"] > 0:
             if 'pause' in extra_features:
-                features['pause'] = strf.pause(t, spikes_df, self.start, self.end, self.pause_cost_weight)
+                features['pause'] = strf.pause(t, spikes_df, self.start, self.end, self.pause_cost)
             if 'burst' in extra_features:
                 features['burst'] = strf.burst(t, spikes_df, self.burst_tol, self.pause_cost)
             if 'delay' in extra_features:

--- a/ipfx/spike_train_features.py
+++ b/ipfx/spike_train_features.py
@@ -84,7 +84,7 @@ def burst(t, spikes_df, tol=0.5, pause_cost=1.0):
     slow_tr_t = spikes_df["slow_trough_t"].values
     thr_v = spikes_df["threshold_v"].values
 
-    bursts = spkf.detect_bursts(isis, isi_types,
+    bursts = detect_bursts(isis, isi_types,
                               fast_tr_v, fast_tr_t,
                               slow_tr_v, slow_tr_t,
                               thr_v, tol, pause_cost)


### PR DESCRIPTION
Small changes :) Pause + burst detect were not working for spike train features. 

1) detect_pauses and detect_bursts not from spike_features.py. 
2). pause cost weight not found in SpikeTrainFeatureExtractor class 